### PR TITLE
Added stream based config reading, Fixed unit test

### DIFF
--- a/core/src/main/java/org/dozer/DozerBeanMapper.java
+++ b/core/src/main/java/org/dozer/DozerBeanMapper.java
@@ -27,6 +27,8 @@ import org.dozer.factory.DestBeanCreator;
 import org.dozer.loader.CustomMappingsLoader;
 import org.dozer.loader.LoadMappingsResult;
 import org.dozer.loader.api.BeanMappingBuilder;
+import org.dozer.loader.xml.MappingStreamReader;
+import org.dozer.loader.xml.XMLParserFactory;
 import org.dozer.metadata.DozerMappingMetadata;
 import org.dozer.metadata.MappingMetadata;
 import org.dozer.stats.GlobalStatistics;
@@ -36,6 +38,7 @@ import org.dozer.stats.StatisticsManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.InputStream;
 import java.lang.reflect.Proxy;
 import java.util.*;
 import java.util.concurrent.CountDownLatch;
@@ -54,6 +57,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * @author tierney.matt
  * @author garsombke.franz
  * @author dmitry.buzdin
+ * @author suwarnaratana.arm
  */
 public class DozerBeanMapper implements Mapper {
 
@@ -214,6 +218,33 @@ public class DozerBeanMapper implements Mapper {
       addMapping(builder);
     }
   }
+  
+	/**
+	 * Add mapping XML from InputStream resources for mapping not stored in
+	 * files (e.g. from database.) The InputStream will be read immediately to
+	 * internally create MappingFileData objects so that the InputStreams may be
+	 * closed after the call to this method.
+	 * 
+	 * @param mappingStreams List of Dozer mapping XML InputStreams
+	 */
+	public void addMappingXMLStreams(List<InputStream> mappingStreams) {
+		checkIfInitialized();
+		MappingStreamReader fileReader = new MappingStreamReader(XMLParserFactory.getInstance());
+		for (InputStream xmlStream : mappingStreams) {
+			MappingFileData mappingFileData = fileReader.read(xmlStream);
+			builderMappings.add(mappingFileData);
+		}
+	}
+
+	/**
+	 * @see DozerBeanMapper#addMappingXMLStreams(List)
+	 * @param mappingStream Dozer mapping XML InputStream
+	 */
+	public void addMappingXMLStream(InputStream mappingStream) {
+		List<InputStream> singleInputStream = new LinkedList<InputStream>();
+		singleInputStream.add(mappingStream);
+		addMappingXMLStreams(singleInputStream);
+	}
 
   /**
    * Adds API mapping to given mapper instance.

--- a/core/src/main/java/org/dozer/loader/xml/MappingFileReader.java
+++ b/core/src/main/java/org/dozer/loader/xml/MappingFileReader.java
@@ -15,19 +15,16 @@
  */
 package org.dozer.loader.xml;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+
 import org.dozer.classmap.MappingFileData;
 import org.dozer.config.BeanContainer;
-import org.dozer.loader.MappingsSource;
 import org.dozer.util.DozerClassLoader;
 import org.dozer.util.MappingUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.w3c.dom.Document;
-
-import javax.xml.parsers.DocumentBuilder;
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.URL;
 
 /**
  * Internal class that reads and parses a single custom mapping xml file into raw ClassMap objects. Only intended for
@@ -36,14 +33,12 @@ import java.net.URL;
  * @author tierney.matt
  * @author garsombke.franz
  */
-public class MappingFileReader {
+public class MappingFileReader extends MappingStreamReader{
 
   private static final Logger log = LoggerFactory.getLogger(MappingFileReader.class);
 
-  private final DocumentBuilder documentBuilder;
-
   public MappingFileReader(XMLParserFactory parserFactory) {
-    documentBuilder = parserFactory.createParser();
+    super(parserFactory);
   }
 
   public MappingFileData read(String fileName) {
@@ -51,20 +46,21 @@ public class MappingFileReader {
     URL url = classLoader.loadResource(fileName);
     return read(url);
   }
+ 
 
   public MappingFileData read(URL url) {
     MappingFileData result = null;
     InputStream stream = null;
     try {
       stream = url.openStream();
-      Document document = documentBuilder.parse(stream);
+
+      /* call the stream reading version */
+      result = read(stream);
       
-      MappingsSource parser = new XMLParser(document);
-      result = parser.load();
-    } catch (Throwable e) {
-      log.error("Error while loading dozer mapping file url: [" + url + "]", e);
-      MappingUtils.throwMappingException(e);
-    } finally {
+    } catch (IOException e) {
+	      log.error("Error while loading dozer mapping file url: [" + url + "]", e);
+	      MappingUtils.throwMappingException(e);
+	} finally {
       try {
         if (stream != null) {
           stream.close();

--- a/core/src/main/java/org/dozer/loader/xml/MappingStreamReader.java
+++ b/core/src/main/java/org/dozer/loader/xml/MappingStreamReader.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2005-2010 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dozer.loader.xml;
+
+import java.io.InputStream;
+
+import javax.xml.parsers.DocumentBuilder;
+
+import org.dozer.classmap.MappingFileData;
+import org.dozer.loader.MappingsSource;
+import org.dozer.util.MappingUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.w3c.dom.Document;
+
+/**
+ * Internal class that reads and parses a single custom mapping XML stream into
+ * raw ClassMap objects. Only intended for internal use.
+ * 
+ * @author suwarnaratana.arm
+ */
+public class MappingStreamReader {
+
+	private static final Logger log = LoggerFactory
+			.getLogger(MappingStreamReader.class);
+
+	private final DocumentBuilder documentBuilder;
+
+	public MappingStreamReader(XMLParserFactory parserFactory) {
+		documentBuilder = parserFactory.createParser();
+	}
+
+	public MappingFileData read(InputStream xmlStream) {
+		MappingFileData result = null;
+		try {
+			Document document = documentBuilder.parse(xmlStream);
+
+			MappingsSource parser = new XMLParser(document);
+			result = parser.load();
+		} catch (Throwable e) {
+			log.error("Error while loading dozer mapping InputStream: ["
+					+ xmlStream + "]", e);
+			MappingUtils.throwMappingException(e);
+		}
+		return result;
+	}
+
+}

--- a/core/src/test/java/org/dozer/functional_tests/InvalidMappingTest.java
+++ b/core/src/test/java/org/dozer/functional_tests/InvalidMappingTest.java
@@ -25,7 +25,7 @@ public class InvalidMappingTest extends AbstractFunctionalTest {
     fail();
   }
 
-  @Test(expected=NullPointerException.class)
+  @Test(expected=MappingException.class)
   public void testEmptyFieldB() {
     mapper = getMapper("invalidmapping3.xml");
     mapper.map("1", Integer.class);


### PR DESCRIPTION
Added the ability to load mapping config from a stream.  This can benefit users that do not store configuration from the file system.  I refactored the MappingFileReader stream reading capability to expose this function.

dozer/core/src/test/java/org/dozer/functional_tests/InvalidMappingTest.java was expecting an NPE but the test creates a Mapping exception.  I corrected this test as it should not generate NPE anymore.  The build test is clean now.
