### PR TITLE
Added support for generic superclass typed properties

### DIFF
--- a/core/src/main/java/org/dozer/propertydescriptor/GetterSetterPropertyDescriptor.java
+++ b/core/src/main/java/org/dozer/propertydescriptor/GetterSetterPropertyDescriptor.java
@@ -161,7 +161,7 @@ public abstract class GetterSetterPropertyDescriptor extends AbstractPropertyDes
                   hierarchyElement.getIndex());
         } else if (Collection.class.isAssignableFrom(clazz)) {
 
-          Class<?> genericType = ReflectionUtils.determineGenericsType(pd);
+          Class<?> genericType = ReflectionUtils.determineGenericsType(parentObj.getClass(), pd);
           if (genericType != null) {
             collectionEntryType = genericType;
           } else {
@@ -197,7 +197,7 @@ public abstract class GetterSetterPropertyDescriptor extends AbstractPropertyDes
           collectionEntryType = pd.getPropertyType().getComponentType();
 
           if (collectionEntryType == null) {
-            collectionEntryType = ReflectionUtils.determineGenericsType(pd);
+            collectionEntryType = ReflectionUtils.determineGenericsType(parentObj.getClass(), pd);
 
             // if the target list is a List that doesn't have type specified, we can
             // try to use the deep-index-hint.  If the list has more than 1 element, there is no
@@ -351,7 +351,7 @@ public abstract class GetterSetterPropertyDescriptor extends AbstractPropertyDes
     Class<?> genericType = null;
     try {
       Method method = getWriteMethod();
-      genericType = ReflectionUtils.determineGenericsType(method, false);
+      genericType = ReflectionUtils.determineGenericsType(clazz, method, false);
     } catch (NoSuchMethodException e) {
       log.warn("The destination object: {} does not have a write method for property : {}", e);
     }

--- a/core/src/main/java/org/dozer/util/ReflectionUtils.java
+++ b/core/src/main/java/org/dozer/util/ReflectionUtils.java
@@ -156,7 +156,7 @@ public final class ReflectionUtils {
         if (latestClass.isArray()) {
           latestClass = latestClass.getComponentType();
         } else if (Collection.class.isAssignableFrom(latestClass)) {
-          Class<?> genericType = determineGenericsType(propDescriptor);
+          Class<?> genericType = determineGenericsType(parentClass.getClass(), propDescriptor);
 
           if (genericType == null && deepIndexHintContainer == null) {
             MappingUtils
@@ -364,21 +364,21 @@ public final class ReflectionUtils {
     return result;
   }
 
-  public static Class<?> determineGenericsType(PropertyDescriptor propDescriptor) {
+  public static Class<?> determineGenericsType(Class<?> parentClazz, PropertyDescriptor propDescriptor) {
     Class<?> result = null;
     //Try getter and setter to determine the Generics type in case one does not exist
     if (propDescriptor.getWriteMethod() != null) {
-      result = determineGenericsType(propDescriptor.getWriteMethod(), false);
+      result = determineGenericsType(parentClazz, propDescriptor.getWriteMethod(), false);
     }
 
     if (result == null && propDescriptor.getReadMethod() != null) {
-      result = determineGenericsType(propDescriptor.getReadMethod(), true);
+      result = determineGenericsType(parentClazz, propDescriptor.getReadMethod(), true);
     }
 
     return result;
   }
 
-  public static Class<?> determineGenericsType(Method method, boolean isReadMethod) {
+  public static Class<?> determineGenericsType(Class<?> clazz, Method method, boolean isReadMethod) {
     Class<?> result = null;
     if (isReadMethod) {
       Type parameterType = method.getGenericReturnType();
@@ -390,6 +390,14 @@ public final class ReflectionUtils {
       }
     }
 
+    if(result == null) {
+      // Have a look at generic superclass
+      Type genericSuperclass = clazz.getGenericSuperclass();
+      if (genericSuperclass != null) {
+        result = determineGenericsType(genericSuperclass);
+      }
+    }
+
     return result;
   }
 
@@ -398,7 +406,9 @@ public final class ReflectionUtils {
     if (type != null && ParameterizedType.class.isAssignableFrom(type.getClass())) {
       Type genericType = ((ParameterizedType) type).getActualTypeArguments()[0];
       if (genericType != null) {
-        result = (Class<?>) genericType;
+         if(! (genericType instanceof TypeVariable)) {
+            result = (Class<?>) genericType;
+         }
       }
     }
     return result;

--- a/core/src/test/java/org/dozer/propertydescriptor/GetterSetterPropertyDescriptorWithGenericSuperClassTest.java
+++ b/core/src/test/java/org/dozer/propertydescriptor/GetterSetterPropertyDescriptorWithGenericSuperClassTest.java
@@ -1,0 +1,29 @@
+package org.dozer.propertydescriptor;
+
+import org.dozer.AbstractDozerTest;
+import org.dozer.fieldmap.DozerField;
+import org.dozer.vo.deep3.Dest;
+import org.dozer.vo.deep3.NestedDest;
+import org.junit.Test;
+
+import java.lang.reflect.Method;
+
+/**
+ * GetterSetterPropertyDescriptorWithGenericSuperClassTest
+ *
+ * @author tetra
+ * @version $Id$
+ */
+public class GetterSetterPropertyDescriptorWithGenericSuperClassTest extends AbstractDozerTest {
+    @Test
+    public void testGetReadMethod() throws Exception {
+      DozerField dozerField = new DozerField("nestedList", "generic");
+
+      JavaBeanPropertyDescriptor pd = new JavaBeanPropertyDescriptor(Dest.class, dozerField.getName(), dozerField.isIndexed(),
+          dozerField.getIndex(), null, null);
+      Class<?> clazz = pd.genericType();
+
+      assertNotNull("clazz should not be null", clazz);
+      assertEquals("NestedDest generic type", NestedDest.class, clazz);
+    }
+}

--- a/core/src/test/java/org/dozer/vo/deep3/AbstractDest.java
+++ b/core/src/test/java/org/dozer/vo/deep3/AbstractDest.java
@@ -1,0 +1,21 @@
+package org.dozer.vo.deep3;
+
+import java.util.List;
+
+/**
+ * AbstractDest
+ *
+ * @author tetra
+ * @version $Id$
+ */
+public class AbstractDest<T> {
+    private List<T> nestedList;
+
+    public List<T> getNestedList() {
+        return nestedList;
+    }
+
+    public void setNestedList(List<T> nestedList) {
+        this.nestedList = nestedList;
+    }
+}

--- a/core/src/test/java/org/dozer/vo/deep3/Dest.java
+++ b/core/src/test/java/org/dozer/vo/deep3/Dest.java
@@ -1,0 +1,10 @@
+package org.dozer.vo.deep3;
+
+/**
+ * Dest
+ *
+ * @author tetra
+ * @version $Id$
+ */
+public class Dest extends AbstractDest<NestedDest> {
+}

--- a/core/src/test/java/org/dozer/vo/deep3/NestedDest.java
+++ b/core/src/test/java/org/dozer/vo/deep3/NestedDest.java
@@ -1,0 +1,19 @@
+package org.dozer.vo.deep3;
+
+/**
+ * NestedDest
+ *
+ * @author tetra
+ * @version $Id$
+ */
+public class NestedDest {
+    private NestedNestedDest nestedNestedDest;
+
+    public NestedNestedDest getNestedNestedDest() {
+        return nestedNestedDest;
+    }
+
+    public void setNestedNestedDest(NestedNestedDest nestedNestedDest) {
+        this.nestedNestedDest = nestedNestedDest;
+    }
+}

--- a/core/src/test/java/org/dozer/vo/deep3/NestedNestedDest.java
+++ b/core/src/test/java/org/dozer/vo/deep3/NestedNestedDest.java
@@ -1,0 +1,10 @@
+package org.dozer.vo.deep3;
+
+/**
+ * NestedNestedDest
+ *
+ * @author tetra
+ * @version $Id$
+ */
+public class NestedNestedDest {
+}


### PR DESCRIPTION
Hello, I just added some support for generic properties where the type comes from the extended superclass. 

ex:  A<T> has a property List<T> list;
If B extends A<Toto> hence the type of the list property is List<Toto>.
Dozer can then guess the type in order to avoid any specific converter.
