### PR TITLE
Improvement of api mappings documentation

### DIFF
--- a/core/src/site/xdoc/documentation/apimappings.xml
+++ b/core/src/site/xdoc/documentation/apimappings.xml
@@ -70,10 +70,15 @@
 
             <source>
               <![CDATA[
+import static org.dozer.loader.api.FieldsMappingOptions.*;
+import static org.dozer.loader.api.TypeMappingOptions.*;
+
+...
+
 BeanMappingBuilder builder = new BeanMappingBuilder() {
       protected void configure() {
         mapping(Bean.class, Bean.class,
-                oneWay(),
+                TypeMappingOptions.oneWay(),
                 mapId("A"),
                 mapNull(true)
         )
@@ -84,7 +89,7 @@ BeanMappingBuilder builder = new BeanMappingBuilder() {
                             RelationshipType.NON_CUMULATIVE),
                         hintA(String.class),
                         hintB(Integer.class),
-                        fieldOneWay(),
+                        FieldsMappingOptions.oneWay(),
                         useMapId("A"),
                         customConverterId("id")
                 )


### PR DESCRIPTION
When I tried to use the code example from the api mappings documentation I first had problems to find the correct imports to use.
So I added them to the code example.

I did not find fieldOneWay so I replaced it with FieldsMappingOptions.oneWay
