### PR TITLE
Patch for 5.4.0 - MappingProcessor - use the processed destType instead of destClass.

### DIFF
--- a/core/src/main/java/org/dozer/MappingProcessor.java
+++ b/core/src/main/java/org/dozer/MappingProcessor.java
@@ -179,7 +179,7 @@ public class MappingProcessor implements Mapper {
       }
 
       // If this is a nested MapperAware conversion this mapping can be already processed
-      Object alreadyMappedValue = mappedFields.getMappedValue(srcObj, destClass);
+      Object alreadyMappedValue = mappedFields.getMappedValue(srcObj, destType);
       if (alreadyMappedValue != null) {
         return (T) alreadyMappedValue;
       }


### PR DESCRIPTION
I fixed an issue we were having when doing a "nested" mapping from within an instanceCoverter (MappingAware). We were getting a Null Pointer. It seems like the destType should be used after it has been created and not the destClass anymore.
