### PR TITLE
Patch for #122 - Mapping fails when a class' getters returntype is inherited from generic type

### DIFF
--- a/core/src/main/java/org/dozer/util/ReflectionUtils.java
+++ b/core/src/main/java/org/dozer/util/ReflectionUtils.java
@@ -90,38 +90,37 @@ public final class ReflectionUtils {
 	 * @param descriptor
 	 * @return
 	 */
-	private static PropertyDescriptor fixGenericDescriptor(Class<?> clazz, PropertyDescriptor descriptor) {
-		Method readMethod = descriptor.getReadMethod();
-		Method writeMethod = descriptor.getWriteMethod();
+    private static PropertyDescriptor fixGenericDescriptor(Class<?> clazz, PropertyDescriptor descriptor) {
+      Method readMethod = descriptor.getReadMethod();
 
-		if(readMethod != null && (readMethod.isBridge() || readMethod.isSynthetic())) {
-		  String propertyName = descriptor.getName();
-		  //capitalize the first letter of the string;
-		  String baseName = Character.toUpperCase(propertyName.charAt(0)) + propertyName.substring(1);
-		  String setMethodName = "set" + baseName;
-		  String getMethodName = "get" + baseName;
-		  Method[] methods = clazz.getMethods();
-			for (Method method : methods) {
-			  if(method.getName().equals(getMethodName) && !method.isBridge() && !method.isSynthetic() ) {
-					try {
-						descriptor.setReadMethod(method);
-					} catch (IntrospectionException e) {
-						//move on
-					}
-				}
-				if(method.getName().equals(setMethodName) && !method.isBridge() && !method.isSynthetic() ) {
-					try {
-						descriptor.setWriteMethod(method);
-					} catch (IntrospectionException e) {
-						//move on
-					}
-				}
-			}
-		}
-		return descriptor;
-	}
+      if(readMethod != null && (readMethod.isBridge() || readMethod.isSynthetic())) {
+        String propertyName = descriptor.getName();
+        //capitalize the first letter of the string;
+        String baseName = Character.toUpperCase(propertyName.charAt(0)) + propertyName.substring(1);
+        String setMethodName = "set" + baseName;
+        String getMethodName = "get" + baseName;
+        Method getMethod = findNonSyntheticMethod(getMethodName, clazz);
+        Method setMethod = findNonSyntheticMethod(setMethodName, clazz);
+        try {
+          return new PropertyDescriptor(propertyName, getMethod, setMethod);
+        } catch (IntrospectionException e) {
+          //move on
+        }
+      }
+      return descriptor;
+    }
 
-	public static DeepHierarchyElement[] getDeepFieldHierarchy(Class<?> parentClass, String field,
+    private static Method findNonSyntheticMethod(String methodName, Class<?> clazz) {
+      Method[] methods = clazz.getMethods();
+      for (Method method : methods) {
+        if(method.getName().equals(methodName) && !method.isBridge() && !method.isSynthetic() ) {
+          return method;
+        }
+      }
+      return null;
+    }
+
+    public static DeepHierarchyElement[] getDeepFieldHierarchy(Class<?> parentClass, String field,
       HintContainer deepIndexHintContainer) {
     if (!MappingUtils.isDeepMapping(field)) {
       MappingUtils.throwMappingException("Field does not contain deep field delimitor");

--- a/core/src/test/java/org/dozer/util/ReflectionUtilsTest.java
+++ b/core/src/test/java/org/dozer/util/ReflectionUtilsTest.java
@@ -172,6 +172,37 @@ public class ReflectionUtilsTest extends AbstractDozerTest {
     fail();
   }
 
+  @Test
+  public void shouldHandleBeanWithGenericInterface() throws Exception {
+    PropertyDescriptor propertyDescriptor = ReflectionUtils.findPropertyDescriptor(Y.class, "x", null);
+    assertEquals("org.dozer.util.ReflectionUtilsTest$ClassInheritsClassX", propertyDescriptor.getReadMethod().getReturnType().getName());
+  }
+
+  public class Y implements HasX<ClassInheritsClassX> {
+    private ClassInheritsClassX x;
+
+    @Override
+    public void setX(ClassInheritsClassX x) {
+      this.x = x;
+    }
+
+    @Override
+    public ClassInheritsClassX getX() {
+      return x;
+    }
+  }
+
+  public interface HasX<X extends ClassX> {
+    void setX(X x);
+    X getX();
+  }
+
+  public class ClassInheritsClassX extends ClassX {
+  }
+
+  public class ClassX {
+  }
+
   public static class BaseBean {
     private String a;
   }


### PR DESCRIPTION
Patch for issue 122

Method fixGenericDescriptor() will now create a new PropertyDescriptor if it finds a synthetic or bridged readmethod instead of failing trying to set readmethod on existing descriptor.

Added testcase showing the problem.
