### PR TITLE
Modified CacheKey's equals method to handle null comparisons.

### DIFF
--- a/core/src/main/java/org/dozer/cache/CacheKeyFactory.java
+++ b/core/src/main/java/org/dozer/cache/CacheKeyFactory.java
@@ -55,29 +55,38 @@ public final class CacheKeyFactory {
     }
 
     @Override
-    public boolean equals(Object o) {
-      CacheKey cacheKey = (CacheKey) o;
-
-      if (destClass != null ? !destClass.equals(cacheKey.destClass) : cacheKey.destClass != null)
+    public boolean equals(final Object o) {
+      if(this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
         return false;
-      if (srcClass != null ? !srcClass.equals(cacheKey.srcClass) : cacheKey.srcClass != null)
+      }
+      final CacheKey cacheKey = (CacheKey) o;
+      if (destClass != null ? !destClass.equals(cacheKey.destClass) : cacheKey.destClass != null) {
         return false;
-      if (mapId != null ? !mapId.equals(cacheKey.mapId) : cacheKey.mapId != null)
+      }
+      if (srcClass != null ? !srcClass.equals(cacheKey.srcClass) : cacheKey.srcClass != null) {
         return false;
-
+      }
+      if (mapId != null ? !mapId.equals(cacheKey.mapId) : cacheKey.mapId != null) {
+        return false;
+      }
       return true;
     }
 
-    @Override
-    public int hashCode() {
-      int result;
-      result = (srcClass != null ? srcClass.hashCode() : 0);
-      result = 31 * result + (destClass != null ? destClass.hashCode() : 0);
-      result = 31 * result + (mapId != null ? mapId.hashCode() : 0);
-      return result;
-    }
 
     @Override
+    public int hashCode() {
+        int result;
+        result = (srcClass != null ? srcClass.hashCode() : 0);
+        result = 31 * result + (destClass != null ? destClass.hashCode() : 0);
+        result = 31 * result + (mapId != null ? mapId.hashCode() : 0);
+        return result;
+    }
+
+
+      @Override
     public String toString() {
       return ReflectionToStringBuilder.toString(this, ToStringStyle.MULTI_LINE_STYLE);
     }

--- a/core/src/test/java/org/dozer/cache/CacheKeyFactoryTest.java
+++ b/core/src/test/java/org/dozer/cache/CacheKeyFactoryTest.java
@@ -53,4 +53,17 @@ public class CacheKeyFactoryTest extends AbstractDozerTest {
     assertFalse(cacheKey.hashCode() == cacheKey2.hashCode());
   }
 
+  @Test
+  public void testCreateKey_handlesNullGracefullyInEquals() throws Exception {
+      Object nullCacheKey = null;
+      Object normalCacheKey = CacheKeyFactory.createKey(String.class, Long.class);
+
+      assertFalse("Null isn't handled properly!", normalCacheKey.equals(nullCacheKey));
+  }
+
+  @Test
+  public void testCreateKey_equivalenceOfSelf() throws Exception {
+    Object cacheKey = CacheKeyFactory.createKey(String.class, Long.class);
+    assertTrue("Key isn't equivalent to self!", cacheKey.equals(cacheKey));
+  }
 }

--- a/sf-migration/pom.xml
+++ b/sf-migration/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>net.sf.dozer</groupId>
     <artifactId>dozer-parent</artifactId>
-    <version>5.4.0-SNAPSHOT</version>
+    <version>5.5.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>sf-migration</artifactId>


### PR DESCRIPTION
Encountered an NPE on an equals method deep in CacheKeyFactory.  This patch only concerns modifying CacheKey to handle a null object when performing equals.

Also updated the POM version for sf-migration; the system would not build successfully due to the version mismatch.
