### PR TITLE
Do not force "get" and "put methods when using Map

### DIFF
--- a/core/src/main/java/org/dozer/propertydescriptor/PropertyDescriptorFactory.java
+++ b/core/src/main/java/org/dozer/propertydescriptor/PropertyDescriptorFactory.java
@@ -1,5 +1,5 @@
-/*
- * Copyright 2005-2017 Dozer Project
+/**
+ * Copyright 2005-2013 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,90 +15,86 @@
  */
 package org.dozer.propertydescriptor;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.CopyOnWriteArrayList;
-
 import org.dozer.fieldmap.HintContainer;
 import org.dozer.util.DozerConstants;
 import org.dozer.util.MappingUtils;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
 /**
  * Internal factory responsible for determining which property descriptor should
  * be used. Only intended for internal use.
- *
+ * 
  * @author garsombke.franz
  */
-public final class PropertyDescriptorFactory {
+public class PropertyDescriptorFactory {
 
-    private static final List<PropertyDescriptorCreationStrategy> pluggedDescriptorCreationStrategies =
-        new ArrayList<PropertyDescriptorCreationStrategy>();
+  private static final List<PropertyDescriptorCreationStrategy> pluggedDescriptorCreationStrategies =
+          new ArrayList<PropertyDescriptorCreationStrategy>();
 
-    private PropertyDescriptorFactory() {
+  private PropertyDescriptorFactory() {
+  }
 
-    }
+  public static DozerPropertyDescriptor getPropertyDescriptor(Class<?> clazz, String theGetMethod, String theSetMethod,
+      String mapGetMethod, String mapSetMethod, boolean isAccessible, boolean isIndexed, int index, String name, String key,
+      boolean isSelfReferencing, String oppositeFieldName, HintContainer srcDeepIndexHintContainer,
+      HintContainer destDeepIndexHintContainer, String beanFactory) {
+    DozerPropertyDescriptor desc = null;
 
-    public static DozerPropertyDescriptor getPropertyDescriptor(Class<?> clazz, String theGetMethod, String theSetMethod,
-                                                                String mapGetMethod, String mapSetMethod, boolean isAccessible,
-                                                                boolean isIndexed, int index, String name, String key, boolean isSelfReferencing,
-                                                                String oppositeFieldName, HintContainer srcDeepIndexHintContainer,
-                                                                HintContainer destDeepIndexHintContainer, String beanFactory) {
-        DozerPropertyDescriptor desc = null;
-
-        // Raw Map types or custom map-get-method/set specified
-        boolean isMapProperty = MappingUtils.isSupportedMap(clazz);
-        if (name.equals(DozerConstants.SELF_KEYWORD) &&
+    // Raw Map types or custom map-get-method/set specified
+    boolean isMapProperty = MappingUtils.isSupportedMap(clazz);
+    if (name.equals(DozerConstants.SELF_KEYWORD) &&
             (mapSetMethod != null || mapGetMethod != null || isMapProperty)) {
-            String setMethod = isMapProperty ? "put" : mapSetMethod;
-            String getMethod = isMapProperty ? "get" : mapGetMethod;
 
-            desc = new MapPropertyDescriptor(clazz, name, isIndexed, index, setMethod,
-                                             getMethod, key != null ? key : oppositeFieldName,
-                                             srcDeepIndexHintContainer, destDeepIndexHintContainer);
+      // If no mapGetMethod is defined, default to "get". If no mapSetMethod is defined, default to "put"
+      String setMethod = StringUtils.isBlank(mapSetMethod) ? "put" : mapSetMethod;
+      String getMethod = StringUtils.isBlank(mapGetMethod) ? "get" : mapGetMethod;
 
-            // Copy by reference(Not mapped backed properties which also use 'this'
-            // identifier for a different purpose)
-        } else if (isSelfReferencing) {
-            desc = new SelfPropertyDescriptor(clazz);
+      desc = new MapPropertyDescriptor(clazz, name, isIndexed, index, setMethod,
+              getMethod, key != null ? key : oppositeFieldName,
+              srcDeepIndexHintContainer, destDeepIndexHintContainer);
 
-            // Access field directly and bypass getter/setters
-        } else if (isAccessible) {
-            desc = new FieldPropertyDescriptor(clazz, name, isIndexed, index, srcDeepIndexHintContainer, destDeepIndexHintContainer);
+      // Copy by reference(Not mapped backed properties which also use 'this'
+      // identifier for a different purpose)
+    } else if (isSelfReferencing) {
+      desc = new SelfPropertyDescriptor(clazz);
 
-            // Custom get-method/set specified
-        } else if (theSetMethod != null || theGetMethod != null) {
-            desc = new CustomGetSetPropertyDescriptor(clazz, name, isIndexed, index, theSetMethod, theGetMethod,
-                                                      srcDeepIndexHintContainer, destDeepIndexHintContainer);
+      // Access field directly and bypass getter/setters
+    } else if (isAccessible) {
+      desc = new FieldPropertyDescriptor(clazz, name, isIndexed, index, srcDeepIndexHintContainer, destDeepIndexHintContainer);
 
-            // If this object is an XML Bean - then use the XmlBeanPropertyDescriptor
-        } else if (beanFactory != null && beanFactory.equals(DozerConstants.XML_BEAN_FACTORY)) {
-            desc = new XmlBeanPropertyDescriptor(clazz, name, isIndexed, index, srcDeepIndexHintContainer, destDeepIndexHintContainer);
-        }
+      // Custom get-method/set specified
+    } else if (theSetMethod != null || theGetMethod != null) {
+      desc = new CustomGetSetPropertyDescriptor(clazz, name, isIndexed, index, theSetMethod, theGetMethod,
+          srcDeepIndexHintContainer, destDeepIndexHintContainer);
 
-        if (desc != null) {
-            return desc;
-        }
+      // If this object is an XML Bean - then use the XmlBeanPropertyDescriptor  
+    } else if (beanFactory != null && beanFactory.equals(DozerConstants.XML_BEAN_FACTORY)) {
+      desc = new XmlBeanPropertyDescriptor(clazz, name, isIndexed, index, srcDeepIndexHintContainer, destDeepIndexHintContainer);
+    }
 
-        for (PropertyDescriptorCreationStrategy propertyDescriptorBuilder :
+    if (desc != null) return desc;
+
+    for (PropertyDescriptorCreationStrategy propertyDescriptorBuilder :
             new CopyOnWriteArrayList<PropertyDescriptorCreationStrategy>(pluggedDescriptorCreationStrategies)) {
-            if (propertyDescriptorBuilder.isApplicable(clazz, name)) {
-                desc = propertyDescriptorBuilder.buildFor(
-                    clazz, name, isIndexed, index, srcDeepIndexHintContainer, destDeepIndexHintContainer);
-                if (desc != null) {
-                    break;
-                }
-            }
-        }
-
-        if (desc == null) {
-            // Everything else. It must be a normal bean with normal custom get/set methods
-            desc = new JavaBeanPropertyDescriptor(clazz, name, isIndexed, index, srcDeepIndexHintContainer, destDeepIndexHintContainer);
-        }
-
-        return desc;
+      if (propertyDescriptorBuilder.isApplicable(clazz, name)) {
+        desc = propertyDescriptorBuilder.buildFor(
+                clazz, name, isIndexed, index, srcDeepIndexHintContainer, destDeepIndexHintContainer);
+        if (desc != null) break;
+      }
     }
 
-    public static void addPluggedPropertyDescriptorCreationStrategy(PropertyDescriptorCreationStrategy strategy) {
-        pluggedDescriptorCreationStrategies.add(strategy);
+    if (desc == null) {
+      // Everything else. It must be a normal bean with normal custom get/set methods
+      desc = new JavaBeanPropertyDescriptor(clazz, name, isIndexed, index, srcDeepIndexHintContainer, destDeepIndexHintContainer);
     }
+
+    return desc;
+  }
+
+  public static void addPluggedPropertyDescriptorCreationStrategy(PropertyDescriptorCreationStrategy strategy) {
+    pluggedDescriptorCreationStrategies.add(strategy);
+  }
 }

--- a/core/src/main/java/org/dozer/propertydescriptor/PropertyDescriptorFactory.java
+++ b/core/src/main/java/org/dozer/propertydescriptor/PropertyDescriptorFactory.java
@@ -49,8 +49,12 @@ public final class PropertyDescriptorFactory {
         boolean isMapProperty = MappingUtils.isSupportedMap(clazz);
         if (name.equals(DozerConstants.SELF_KEYWORD) &&
             (mapSetMethod != null || mapGetMethod != null || isMapProperty)) {
-            String setMethod = isMapProperty ? "put" : mapSetMethod;
-            String getMethod = isMapProperty ? "get" : mapGetMethod;
+
+            // If no mapSetMethod is defined, default to "put"
+            String setMethod = StringUtils.isBlank(mapSetMethod) ? "put" : mapSetMethod;
+            
+            // If no mapGetMethod is defined, default to "get".
+            String getMethod = StringUtils.isBlank(mapGetMethod) ? "get" : mapGetMethod;
 
             desc = new MapPropertyDescriptor(clazz, name, isIndexed, index, setMethod,
                                              getMethod, key != null ? key : oppositeFieldName,

--- a/core/src/main/java/org/dozer/propertydescriptor/PropertyDescriptorFactory.java
+++ b/core/src/main/java/org/dozer/propertydescriptor/PropertyDescriptorFactory.java
@@ -1,5 +1,5 @@
-/**
- * Copyright 2005-2013 Dozer Project
+/*
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,86 +15,90 @@
  */
 package org.dozer.propertydescriptor;
 
-import org.dozer.fieldmap.HintContainer;
-import org.dozer.util.DozerConstants;
-import org.dozer.util.MappingUtils;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 
+import org.dozer.fieldmap.HintContainer;
+import org.dozer.util.DozerConstants;
+import org.dozer.util.MappingUtils;
+
 /**
  * Internal factory responsible for determining which property descriptor should
  * be used. Only intended for internal use.
- * 
+ *
  * @author garsombke.franz
  */
-public class PropertyDescriptorFactory {
+public final class PropertyDescriptorFactory {
 
-  private static final List<PropertyDescriptorCreationStrategy> pluggedDescriptorCreationStrategies =
-          new ArrayList<PropertyDescriptorCreationStrategy>();
+    private static final List<PropertyDescriptorCreationStrategy> pluggedDescriptorCreationStrategies =
+        new ArrayList<PropertyDescriptorCreationStrategy>();
 
-  private PropertyDescriptorFactory() {
-  }
+    private PropertyDescriptorFactory() {
 
-  public static DozerPropertyDescriptor getPropertyDescriptor(Class<?> clazz, String theGetMethod, String theSetMethod,
-      String mapGetMethod, String mapSetMethod, boolean isAccessible, boolean isIndexed, int index, String name, String key,
-      boolean isSelfReferencing, String oppositeFieldName, HintContainer srcDeepIndexHintContainer,
-      HintContainer destDeepIndexHintContainer, String beanFactory) {
-    DozerPropertyDescriptor desc = null;
+    }
 
-    // Raw Map types or custom map-get-method/set specified
-    boolean isMapProperty = MappingUtils.isSupportedMap(clazz);
-    if (name.equals(DozerConstants.SELF_KEYWORD) &&
+    public static DozerPropertyDescriptor getPropertyDescriptor(Class<?> clazz, String theGetMethod, String theSetMethod,
+                                                                String mapGetMethod, String mapSetMethod, boolean isAccessible,
+                                                                boolean isIndexed, int index, String name, String key, boolean isSelfReferencing,
+                                                                String oppositeFieldName, HintContainer srcDeepIndexHintContainer,
+                                                                HintContainer destDeepIndexHintContainer, String beanFactory) {
+        DozerPropertyDescriptor desc = null;
+
+        // Raw Map types or custom map-get-method/set specified
+        boolean isMapProperty = MappingUtils.isSupportedMap(clazz);
+        if (name.equals(DozerConstants.SELF_KEYWORD) &&
             (mapSetMethod != null || mapGetMethod != null || isMapProperty)) {
+            String setMethod = isMapProperty ? "put" : mapSetMethod;
+            String getMethod = isMapProperty ? "get" : mapGetMethod;
 
-      // If no mapGetMethod is defined, default to "get". If no mapSetMethod is defined, default to "put"
-      String setMethod = StringUtils.isBlank(mapSetMethod) ? "put" : mapSetMethod;
-      String getMethod = StringUtils.isBlank(mapGetMethod) ? "get" : mapGetMethod;
+            desc = new MapPropertyDescriptor(clazz, name, isIndexed, index, setMethod,
+                                             getMethod, key != null ? key : oppositeFieldName,
+                                             srcDeepIndexHintContainer, destDeepIndexHintContainer);
 
-      desc = new MapPropertyDescriptor(clazz, name, isIndexed, index, setMethod,
-              getMethod, key != null ? key : oppositeFieldName,
-              srcDeepIndexHintContainer, destDeepIndexHintContainer);
+            // Copy by reference(Not mapped backed properties which also use 'this'
+            // identifier for a different purpose)
+        } else if (isSelfReferencing) {
+            desc = new SelfPropertyDescriptor(clazz);
 
-      // Copy by reference(Not mapped backed properties which also use 'this'
-      // identifier for a different purpose)
-    } else if (isSelfReferencing) {
-      desc = new SelfPropertyDescriptor(clazz);
+            // Access field directly and bypass getter/setters
+        } else if (isAccessible) {
+            desc = new FieldPropertyDescriptor(clazz, name, isIndexed, index, srcDeepIndexHintContainer, destDeepIndexHintContainer);
 
-      // Access field directly and bypass getter/setters
-    } else if (isAccessible) {
-      desc = new FieldPropertyDescriptor(clazz, name, isIndexed, index, srcDeepIndexHintContainer, destDeepIndexHintContainer);
+            // Custom get-method/set specified
+        } else if (theSetMethod != null || theGetMethod != null) {
+            desc = new CustomGetSetPropertyDescriptor(clazz, name, isIndexed, index, theSetMethod, theGetMethod,
+                                                      srcDeepIndexHintContainer, destDeepIndexHintContainer);
 
-      // Custom get-method/set specified
-    } else if (theSetMethod != null || theGetMethod != null) {
-      desc = new CustomGetSetPropertyDescriptor(clazz, name, isIndexed, index, theSetMethod, theGetMethod,
-          srcDeepIndexHintContainer, destDeepIndexHintContainer);
+            // If this object is an XML Bean - then use the XmlBeanPropertyDescriptor
+        } else if (beanFactory != null && beanFactory.equals(DozerConstants.XML_BEAN_FACTORY)) {
+            desc = new XmlBeanPropertyDescriptor(clazz, name, isIndexed, index, srcDeepIndexHintContainer, destDeepIndexHintContainer);
+        }
 
-      // If this object is an XML Bean - then use the XmlBeanPropertyDescriptor  
-    } else if (beanFactory != null && beanFactory.equals(DozerConstants.XML_BEAN_FACTORY)) {
-      desc = new XmlBeanPropertyDescriptor(clazz, name, isIndexed, index, srcDeepIndexHintContainer, destDeepIndexHintContainer);
-    }
+        if (desc != null) {
+            return desc;
+        }
 
-    if (desc != null) return desc;
-
-    for (PropertyDescriptorCreationStrategy propertyDescriptorBuilder :
+        for (PropertyDescriptorCreationStrategy propertyDescriptorBuilder :
             new CopyOnWriteArrayList<PropertyDescriptorCreationStrategy>(pluggedDescriptorCreationStrategies)) {
-      if (propertyDescriptorBuilder.isApplicable(clazz, name)) {
-        desc = propertyDescriptorBuilder.buildFor(
-                clazz, name, isIndexed, index, srcDeepIndexHintContainer, destDeepIndexHintContainer);
-        if (desc != null) break;
-      }
+            if (propertyDescriptorBuilder.isApplicable(clazz, name)) {
+                desc = propertyDescriptorBuilder.buildFor(
+                    clazz, name, isIndexed, index, srcDeepIndexHintContainer, destDeepIndexHintContainer);
+                if (desc != null) {
+                    break;
+                }
+            }
+        }
+
+        if (desc == null) {
+            // Everything else. It must be a normal bean with normal custom get/set methods
+            desc = new JavaBeanPropertyDescriptor(clazz, name, isIndexed, index, srcDeepIndexHintContainer, destDeepIndexHintContainer);
+        }
+
+        return desc;
     }
 
-    if (desc == null) {
-      // Everything else. It must be a normal bean with normal custom get/set methods
-      desc = new JavaBeanPropertyDescriptor(clazz, name, isIndexed, index, srcDeepIndexHintContainer, destDeepIndexHintContainer);
+    public static void addPluggedPropertyDescriptorCreationStrategy(PropertyDescriptorCreationStrategy strategy) {
+        pluggedDescriptorCreationStrategies.add(strategy);
     }
-
-    return desc;
-  }
-
-  public static void addPluggedPropertyDescriptorCreationStrategy(PropertyDescriptorCreationStrategy strategy) {
-    pluggedDescriptorCreationStrategies.add(strategy);
-  }
 }

--- a/core/src/main/java/org/dozer/propertydescriptor/PropertyDescriptorFactory.java
+++ b/core/src/main/java/org/dozer/propertydescriptor/PropertyDescriptorFactory.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 
+import org.apache.commons.lang3.StringUtils;
 import org.dozer.fieldmap.HintContainer;
 import org.dozer.util.DozerConstants;
 import org.dozer.util.MappingUtils;

--- a/core/src/test/java/org/dozer/functional_tests/MapWithCustomGetAndPutMethodTest.java
+++ b/core/src/test/java/org/dozer/functional_tests/MapWithCustomGetAndPutMethodTest.java
@@ -15,94 +15,272 @@
  */
 package org.dozer.functional_tests;
 
-import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 
-import org.dozer.vo.TestObject;
-import org.dozer.vo.map.MapToMap;
-import org.dozer.vo.map.MapToMapPrime;
-import org.junit.Before;
-import org.junit.Ignore;
+import org.dozer.DozerBeanMapper;
+import org.dozer.MappingException;
+import org.dozer.loader.api.BeanMappingBuilder;
+import org.dozer.loader.api.TypeDefinition;
+import org.hamcrest.number.IsCloseTo;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 
-/**
- * @author Dmitry Buzdin
- */
 public class MapWithCustomGetAndPutMethodTest extends AbstractFunctionalTest {
 
-	/**
-	 * <mapping>
-		<class-a is-accessible="true">tsb.portal.controller.base.PortalResponse</class-a>
-		<class-b map-set-method="putUnknownType" map-get-method="get">tsb.grandcentral.collection.ObjectMap</class-b>
-		<!-- <field> -->
-		<!-- <a is-accessible="true">error</a> -->
-		<!-- <b key="error">this</b> -->
-		<!-- </field> -->
-		<field>
-			<a>errorCode</a>
-			<b key="errorCode">this</b>
-		</field>
-		<field>
-			<a>errorMessage</a>
-			<b key="errorMessage">this</b>
-		</field>
-		<field-exclude>
-			<a>error</a>
-			<b>error</b>
-		</field-exclude>
-		</mapping>
-	 */
 
-	
-	/**
-	 @Autowired
-	private DozerBeanMapper mapper;
+  @Test
+  public void testDefaultMapBehaviour_UseDefaultGetAndPutMethod() {
+    DozerBeanMapper defaultMapper = new DozerBeanMapper();
+    
+    // Map to Object, should use "get"
+    MapWithCustomGetAndPut input1 = MapWithCustomGetAndPut.createInput();
+    ValueContainer output1 = defaultMapper.map(input1, ValueContainer.class);
 
-	@Test
-	public void mapObjectMapWithErrorMessageTOPortalRespone_ValidSessionId_IdenticalOutput() {
-		String errorMessage = "messyage";
+    assertThat(output1.getEmptyString(), is(""));
+    assertThat(output1.getStringValue(), is("String"));
+    assertThat(output1.getIntValue(), is(123));
+    assertThat(output1.getDoubleValue(), is(IsCloseTo.closeTo(123.456, 0.00001)));
+    
+    
+    // Object to Map, should use "put"
+    ValueContainer input2 = ValueContainer.createInput();
+    MapWithCustomGetAndPut output2 = defaultMapper.map(input2, MapWithCustomGetAndPut.class);
 
-		ObjectMap input = new ObjectMap();
-		input.add("errorMessage", errorMessage);
+    assertThat(output2.get("emptyString"), is(""));
+    assertThat(output2.get("stringValue"), is("Different String"));
+    assertThat(output2.get("intValue"), is(-987));
+    assertThat(output2.get("doubleValue"), is(-987.654));
+  }
 
-		PortalResponse response = this.mapper.map(input, PortalResponse.class);
-		assertThat(response.getErrorMessage(), is(equalTo(errorMessage)));
-		assertThat(response.getError(), is(true));
-		assertThat(response.getErrorCode(), is(nullValue()));
-	}
+  @Test
+  public void testMapWithCustomMethods_UseSpecifiedMethods() {
+    DozerBeanMapper customMapper = new DozerBeanMapper();
+    customMapper.addMapping(new BeanMappingBuilder() {
+      @Override
+      protected void configure() {
+        mapping(
+            ValueContainer.class, 
+            new TypeDefinition(MapWithCustomGetAndPut.class).mapMethods("customGet", "customPut")
+            );
+      }
+    });
+    
+    // Map to Object, should use "customGet"
+    MapWithCustomGetAndPut input1 = MapWithCustomGetAndPut.createInput();
+    ValueContainer output1 = customMapper.map(input1, ValueContainer.class);
 
-	@Test
-	public void mapObjectMapWithErrorMessageAndCodeTOPortalRespone_ValidSessionId_IdenticalOutput() {
-		String errorMessage = "coded message";
-		String errorCode = "911";
+    assertThat(output1.getEmptyString(), is("Map contains EMPTY"));
+    assertThat(output1.getStringValue(), is("String"));
+    assertThat(output1.getIntValue(), is(123));
+    assertThat(output1.getDoubleValue(), is(IsCloseTo.closeTo(123.456, 0.00001)));
 
-		ObjectMap input = new ObjectMap();
-		input.add("errorMessage", errorMessage);
-		input.add("errorCode", errorCode);
+    // Object to Map, should use "customPut"
+    ValueContainer input = ValueContainer.createInput();
+    MapWithCustomGetAndPut output = customMapper.map(input, MapWithCustomGetAndPut.class);
 
-		PortalResponse response = this.mapper.map(input, PortalResponse.class);
-		assertThat(response.getErrorMessage(), is(equalTo(errorMessage)));
-		assertThat(response.getError(), is(true));
-		assertThat(response.getErrorCode(), is(equalTo(errorCode)));
-	}
+    assertThat(output.get("emptyString"), is("Tried to insert EMPTY"));
+    assertThat(output.get("stringValue"), is("Different String"));
+    assertThat(output.get("intValue"), is(987)); // only the Int should be absolute
+    assertThat(output.get("doubleValue"), is(-987.654));
+  }
 
-	@Test
-	public void mapObjectMapWithNoErrorMessageTOPortalRespone_ValidSessionId_IdenticalOutput() {
-		ObjectMap input = new ObjectMap();
+  @Test
+  public void testMapWithNullGetAndPutMethods_FallbackToDefaultMethods() {
+    DozerBeanMapper nullMapper = new DozerBeanMapper();
+    nullMapper.addMapping(new BeanMappingBuilder() {
+      @Override
+      protected void configure() {
+        mapping(
+            ValueContainer.class, 
+            new TypeDefinition(MapWithCustomGetAndPut.class).mapMethods(null, null)
+            );
+      }
+    });
+    
+    // Map to Object, should use "get"
+    MapWithCustomGetAndPut input1 = MapWithCustomGetAndPut.createInput();
+    ValueContainer output1 = nullMapper.map(input1, ValueContainer.class);
+    
+    assertThat(output1.getEmptyString(), is(""));
+    assertThat(output1.getStringValue(), is("String"));
+    assertThat(output1.getIntValue(), is(123));
+    assertThat(output1.getDoubleValue(), is(IsCloseTo.closeTo(123.456, 0.00001)));
+    
+    // Object to Map, should use "put"
+    ValueContainer input2 = ValueContainer.createInput();
+    MapWithCustomGetAndPut output2 = nullMapper.map(input2, MapWithCustomGetAndPut.class);
+    
+    assertThat(output2.get("emptyString"), is(""));
+    assertThat(output2.get("stringValue"), is("Different String"));
+    assertThat(output2.get("intValue"), is(-987));
+    assertThat(output2.get("doubleValue"), is(-987.654));
+  }
+  
+  @Test
+  public void testMapWithEmptyGetAndPutMethods_FallbackToDefaultMethods() {
+    DozerBeanMapper emptyMapper = new DozerBeanMapper();
+    emptyMapper.addMapping(new BeanMappingBuilder() {
+      @Override
+      protected void configure() {
+        mapping(
+            ValueContainer.class, 
+            new TypeDefinition(MapWithCustomGetAndPut.class).mapMethods("", "")
+            );
+      }
+    });
+    
+    // Map to Object, should use "get"
+    MapWithCustomGetAndPut input1 = MapWithCustomGetAndPut.createInput();
+    ValueContainer output1 = emptyMapper.map(input1, ValueContainer.class);
+    
+    assertThat(output1.getEmptyString(), is(""));
+    assertThat(output1.getStringValue(), is("String"));
+    assertThat(output1.getIntValue(), is(123));
+    assertThat(output1.getDoubleValue(), is(IsCloseTo.closeTo(123.456, 0.00001)));
+    
+    // Object to Map, should use "put"
+    ValueContainer input2 = ValueContainer.createInput();
+    MapWithCustomGetAndPut output2 = emptyMapper.map(input2, MapWithCustomGetAndPut.class);
+    
+    assertThat(output2.get("emptyString"), is(""));
+    assertThat(output2.get("stringValue"), is("Different String"));
+    assertThat(output2.get("intValue"), is(-987));
+    assertThat(output2.get("doubleValue"), is(-987.654));
+  }
+  
+  /**
+   * This is simply to make sure we are trying to be 'too intelligent' and still throwing exceptions
+   * if non-existent methods are configured.
+   */
+  @Test(expected=MappingException.class)
+  public void testMapWithInvalidGetMethod_ThrowsMappingException() {
+    DozerBeanMapper invalidMapper = new DozerBeanMapper();
+    invalidMapper.addMapping(new BeanMappingBuilder() {
+      @Override
+      protected void configure() {
+        mapping(
+            ValueContainer.class, 
+            new TypeDefinition(MapWithCustomGetAndPut.class).mapMethods("invalidGetMethod", "invalidPutMethod")
+            );
+      }
+    });
+    
+    // Map to Object, will try to  use "invalidGetMethod"
+    MapWithCustomGetAndPut input = MapWithCustomGetAndPut.createInput();
+    invalidMapper.map(input, ValueContainer.class);
+    
+    fail("Expected MappingException");
+  }
+  
+  /**
+   * This is simply to make sure we are trying to be 'too intelligent' and still throwing exceptions
+   * if non-existent methods are configured.
+   */
+  @Test(expected=MappingException.class)
+  public void testMapWithInvalidPutMethod_ThrowsMappingException() {
+    DozerBeanMapper invalidMapper = new DozerBeanMapper();
+    invalidMapper.addMapping(new BeanMappingBuilder() {
+      @Override
+      protected void configure() {
+        mapping(
+            ValueContainer.class, 
+            new TypeDefinition(MapWithCustomGetAndPut.class).mapMethods("invalidGetMethod", "invalidPutMethod")
+            );
+      }
+    });
 
-		PortalResponse response = this.mapper.map(input, PortalResponse.class);
-		assertThat(response.getError(), is(false));
-		assertThat(response.getErrorMessage(), is(nullValue()));
-		assertThat(response.getErrorCode(), is(nullValue()));
-	}
-	 */
+    // Object to Map, will try to  use "invalidPutMethod"
+    ValueContainer input = ValueContainer.createInput();
+    invalidMapper.map(input, MapWithCustomGetAndPut.class);
+
+    fail("Expected MappingException");
+  }
+
+  protected static class MapWithCustomGetAndPut extends HashMap<String, Object> {
+
+    private static final long serialVersionUID = 3085080961637343951L;
+
+    public Object customGet(Object key) {
+      Object value = super.get(key);
+
+      if (value.equals("")) {
+        return "Map contains EMPTY";
+      } else {
+        return value;
+      }
+    }
+
+    public Object customPut(String key, Object value) {
+      Object valueToInsert = value;
+
+      if (value.equals("") ) {
+        valueToInsert = "Tried to insert EMPTY";
+      } else if (value instanceof Integer) {
+        // for testing purposes, we convert integers to absolute value
+        valueToInsert = Math.abs((Integer)value);
+      }
+
+      super.put(key, valueToInsert);
+
+      return valueToInsert;
+    }
+
+    public static MapWithCustomGetAndPut createInput() {
+      MapWithCustomGetAndPut result = new MapWithCustomGetAndPut();
+      result.put("emptyString", "");
+      result.put("stringValue", "String");
+      result.put("intValue", 123);
+      result.put("doubleValue", 123.456);
+      return result;
+    }
+  }
+
+  protected static class ValueContainer {
+
+    private String emptyString;
+    private String stringValue;
+    private int intValue;
+    private double doubleValue;
+
+    public String getEmptyString() {
+      return emptyString;
+    }
+    public void setEmptyString(String nullString) {
+      this.emptyString = nullString;
+    }
+
+    public String getStringValue() {
+      return stringValue;
+    }
+    public void setStringValue(String stringValue) {
+      this.stringValue = stringValue;
+    }
+
+    public int getIntValue() {
+      return intValue;
+    }
+    public void setIntValue(int intValue) {
+      this.intValue = intValue;
+    }
+
+    public double getDoubleValue() {
+      return doubleValue;
+    }
+    public void setDoubleValue(double doubleValue) {
+      this.doubleValue = doubleValue;
+    }
+
+    public static ValueContainer createInput() {
+      ValueContainer result = new ValueContainer();
+      result.emptyString = "";
+      result.stringValue = "Different String";
+      result.intValue = -987;
+      result.doubleValue = -987.654;
+      return result;
+    }
+  }
+
 }

--- a/core/src/test/java/org/dozer/functional_tests/MapWithCustomGetAndPutMethodTest.java
+++ b/core/src/test/java/org/dozer/functional_tests/MapWithCustomGetAndPutMethodTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2005-2017 Dozer Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dozer.functional_tests;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.dozer.vo.TestObject;
+import org.dozer.vo.map.MapToMap;
+import org.dozer.vo.map.MapToMapPrime;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @author Dmitry Buzdin
+ */
+public class MapWithCustomGetAndPutMethodTest extends AbstractFunctionalTest {
+
+	/**
+	 * <mapping>
+		<class-a is-accessible="true">tsb.portal.controller.base.PortalResponse</class-a>
+		<class-b map-set-method="putUnknownType" map-get-method="get">tsb.grandcentral.collection.ObjectMap</class-b>
+		<!-- <field> -->
+		<!-- <a is-accessible="true">error</a> -->
+		<!-- <b key="error">this</b> -->
+		<!-- </field> -->
+		<field>
+			<a>errorCode</a>
+			<b key="errorCode">this</b>
+		</field>
+		<field>
+			<a>errorMessage</a>
+			<b key="errorMessage">this</b>
+		</field>
+		<field-exclude>
+			<a>error</a>
+			<b>error</b>
+		</field-exclude>
+		</mapping>
+	 */
+
+	
+	/**
+	 @Autowired
+	private DozerBeanMapper mapper;
+
+	@Test
+	public void mapObjectMapWithErrorMessageTOPortalRespone_ValidSessionId_IdenticalOutput() {
+		String errorMessage = "messyage";
+
+		ObjectMap input = new ObjectMap();
+		input.add("errorMessage", errorMessage);
+
+		PortalResponse response = this.mapper.map(input, PortalResponse.class);
+		assertThat(response.getErrorMessage(), is(equalTo(errorMessage)));
+		assertThat(response.getError(), is(true));
+		assertThat(response.getErrorCode(), is(nullValue()));
+	}
+
+	@Test
+	public void mapObjectMapWithErrorMessageAndCodeTOPortalRespone_ValidSessionId_IdenticalOutput() {
+		String errorMessage = "coded message";
+		String errorCode = "911";
+
+		ObjectMap input = new ObjectMap();
+		input.add("errorMessage", errorMessage);
+		input.add("errorCode", errorCode);
+
+		PortalResponse response = this.mapper.map(input, PortalResponse.class);
+		assertThat(response.getErrorMessage(), is(equalTo(errorMessage)));
+		assertThat(response.getError(), is(true));
+		assertThat(response.getErrorCode(), is(equalTo(errorCode)));
+	}
+
+	@Test
+	public void mapObjectMapWithNoErrorMessageTOPortalRespone_ValidSessionId_IdenticalOutput() {
+		ObjectMap input = new ObjectMap();
+
+		PortalResponse response = this.mapper.map(input, PortalResponse.class);
+		assertThat(response.getError(), is(false));
+		assertThat(response.getErrorMessage(), is(nullValue()));
+		assertThat(response.getErrorCode(), is(nullValue()));
+	}
+	 */
+}


### PR DESCRIPTION
Allow custom map-set and map-get methods to be defined even when using a subclass of _java.util.Map_.  If no _mapGetMethod_ is defined, default to "get". If no _mapSetMethod_ is defined, default to "put".

This was a requirement for us because we created a subclass of _java.util.Map<String, Object>_ with a bunch of overloaded _put()_ methods that did a sanity checking and/or conversion.  The put method was deprecated to force typed methods to be used.  We also added a _putUnknownType(String, Object)_ method that had a few instanceof checks and then called the required put method for the discovered type.

When we ran this through Dozer, it would work mostly in the JUnit test (picked up deprecated _put(String, Object)_ method) but it failed in our integration test because it picked up a different version of the _put_ method (most of the time it was _put(String, Double)_ )

Since the _MapPropertyDescriptor_ had no knowledge of the destination type, we could not change the _getWriteMethod_ method to look for a specific overloaded version of the setMethod.  And _Class.getMethods_ return the methods in an unspecified order.

So we tried the custom map-set-method path.  But it seemed to have no effect.  Which is when we realized our configuration property was being overridden because of the _isMapProperty_ flag in _PropertyDescriptorFactory_.

We have implemented this change locally and it meets all our requirements.  If anybody else has the same problem, this will work for them as well.

I do not foresee any problems added by this change, except maybe for when you are using a custom map and did not provide a get/set method it will now default to "get"/"put", which might cause a MethodNotFoundException.
