### PR TITLE
Fix to allow indexed elements when mapping heirarchy elements

### DIFF
--- a/core/src/main/java/org/dozer/loader/DozerBuilder.java
+++ b/core/src/main/java/org/dozer/loader/DozerBuilder.java
@@ -423,15 +423,15 @@ public class DozerBuilder {
   }
 
 
-  private static boolean isIndexed(String fieldName) {
+  public static boolean isIndexed(String fieldName) {
     return (fieldName != null) && (fieldName.matches(".+\\[\\d+\\]"));
   }
 
-  static String getFieldNameOfIndexedField(String fieldName) {
+  public static String getFieldNameOfIndexedField(String fieldName) {
     return fieldName == null ? null : fieldName.replaceAll("\\[\\d+\\]$", "");
   }
 
-  private static int getIndexOfIndexedField(String fieldName) {
+  public static int getIndexOfIndexedField(String fieldName) {
     return Integer.parseInt(fieldName.replaceAll(".*\\[", "").replaceAll("\\]", ""));
   }
 

--- a/core/src/main/java/org/dozer/propertydescriptor/FieldPropertyDescriptor.java
+++ b/core/src/main/java/org/dozer/propertydescriptor/FieldPropertyDescriptor.java
@@ -18,6 +18,8 @@ package org.dozer.propertydescriptor;
 import org.dozer.factory.DestBeanCreator;
 import org.dozer.fieldmap.FieldMap;
 import org.dozer.fieldmap.HintContainer;
+import org.dozer.loader.DozerBuilder;
+import org.dozer.util.CollectionUtils;
 import org.dozer.util.DozerConstants;
 import org.dozer.util.MappingUtils;
 import org.dozer.util.ReflectionUtils;


### PR DESCRIPTION
Fix has been made for below problem. DozerBuilder.java and FieldPropertyDescriptor.java has been modified. A week back I have raised the same issue. Issue# 164. Please let me know if changes are fine.

Problem when mapping below fields:
fieldA
fieldB[0].attribute1

When mapping fields as specified above and there is no set method available for fieldB. So i used is-accessible="true" for class b. When I do this Dozer does not recognize that fieldB is a list and hence it has to strip [0] when searching for the field name on the class.
