### PR TITLE
Resolves #83 (Add built-in support for java.util.UUID)

### DIFF
--- a/core/src/main/java/org/dozer/converters/CustomConverterContainer.java
+++ b/core/src/main/java/org/dozer/converters/CustomConverterContainer.java
@@ -70,7 +70,7 @@ public class CustomConverterContainer {
     return appropriateConverter;
   }
 
-  private Class findConverter(Class src, Class dest) {
+  public Class findConverter(Class src, Class dest) {
     // Otherwise, loop through custom converters and look for a match. Also, store the result in the cache
     for (CustomConverterDescription customConverter : converters) {
       final Class classA = customConverter.getClassA();

--- a/core/src/main/java/org/dozer/loader/CustomMappingsLoader.java
+++ b/core/src/main/java/org/dozer/loader/CustomMappingsLoader.java
@@ -15,16 +15,14 @@
  */
 package org.dozer.loader;
 
+import org.dozer.CustomConverter;
 import org.dozer.classmap.*;
 import org.dozer.converters.CustomConverterContainer;
 import org.dozer.converters.CustomConverterDescription;
 import org.dozer.util.MappingUtils;
 
-import java.util.ArrayList;
-import java.util.LinkedHashSet;
-import java.util.List;
+import java.util.*;
 import java.util.Map.Entry;
-import java.util.Set;
 
 /**
  * Internal class that loads and parses custom xml mapping files into ClassMap objects. The ClassMap objects returned
@@ -73,6 +71,9 @@ public class CustomMappingsLoader {
         classMap.getCustomConverters().setConverters(new ArrayList<CustomConverterDescription>(customConverterDescriptions));
       }
     }
+
+    addDefaultCustomConverters(globalConfiguration);
+
     return new LoadMappingsResult(customMappings, globalConfiguration);
   }
 
@@ -97,6 +98,27 @@ public class CustomMappingsLoader {
     }
 
     return globalConfiguration;
+  }
+
+  private void addDefaultCustomConverters(Configuration globalConfiguration) {
+      if (globalConfiguration.getCustomConverters() != null &&
+              globalConfiguration.getCustomConverters().findConverter(UUID.class, UUID.class) == null) {
+          CustomConverterDescription defaultUUIDConverter = new CustomConverterDescription();
+          defaultUUIDConverter.setClassA(UUID.class);
+          defaultUUIDConverter.setClassB(UUID.class);
+          defaultUUIDConverter.setType(ByReferenceConverter.class);
+          globalConfiguration.getCustomConverters().addConverter(defaultUUIDConverter);
+      }
+  }
+
+  /**
+   *  Returns the source field value as a reference, regardless of other parameters.
+   *  Only intended for internal use. */
+  public static class ByReferenceConverter implements CustomConverter {
+      @Override
+      public Object convert(Object existingDestinationFieldValue, Object sourceFieldValue, Class<?> destinationClass, Class<?> sourceClass) {
+          return sourceFieldValue;
+      }
   }
 
 }

--- a/core/src/test/java/org/dozer/functional_tests/UUIDMappingTest.java
+++ b/core/src/test/java/org/dozer/functional_tests/UUIDMappingTest.java
@@ -1,0 +1,19 @@
+package org.dozer.functional_tests;
+
+import org.junit.Test;
+
+import java.util.UUID;
+
+import static org.junit.Assert.assertTrue;
+
+public class UUIDMappingTest extends AbstractFunctionalTest {
+
+    @Test
+    public void testCopyUUIDByReferenceAsDefault() {
+        UUID uuidToMap = UUID.randomUUID();
+        UUID mappedUUID = mapper.map(uuidToMap, UUID.class);
+
+        assertTrue(mappedUUID == uuidToMap);
+    }
+
+}


### PR DESCRIPTION
Added a default CustomConverter for UUIDs to resolve #83. If there is a more elegant way to implement this, please let me know.
