### PR TITLE
Resolves #23 (Class level is-accessible doesn't work)

### DIFF
--- a/core/src/main/java/org/dozer/classmap/ClassMapBuilder.java
+++ b/core/src/main/java/org/dozer/classmap/ClassMapBuilder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2014 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,9 +17,10 @@ package org.dozer.classmap;
 
 import org.apache.commons.lang3.StringUtils;
 import org.dozer.Mapping;
-import org.dozer.MappingException;
 import org.dozer.classmap.generator.BeanMappingGenerator;
+import org.dozer.classmap.generator.ClassLevelFieldMappingGenerator;
 import org.dozer.classmap.generator.GeneratorUtils;
+import org.dozer.classmap.generator.MappingType;
 import org.dozer.fieldmap.DozerField;
 import org.dozer.fieldmap.FieldMap;
 import org.dozer.fieldmap.GenericFieldMap;
@@ -30,7 +31,6 @@ import org.dozer.util.ReflectionUtils;
 
 import java.beans.PropertyDescriptor;
 import java.lang.reflect.Field;
-import java.lang.reflect.Member;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
@@ -50,12 +50,14 @@ public final class ClassMapBuilder {
   static final List<ClassMappingGenerator> runTimeGenerators = new ArrayList<ClassMappingGenerator>();
 
   static {
+    buildTimeGenerators.add(new ClassLevelFieldMappingGenerator());
     buildTimeGenerators.add(new AnnotationPropertiesGenerator());
     buildTimeGenerators.add(new AnnotationFieldsGenerator());
     buildTimeGenerators.add(new MapMappingGenerator());
     buildTimeGenerators.add(new BeanMappingGenerator());
     buildTimeGenerators.add(new CollectionMappingGenerator());
 
+    runTimeGenerators.add(new ClassLevelFieldMappingGenerator());
     runTimeGenerators.add(new AnnotationPropertiesGenerator());
     runTimeGenerators.add(new AnnotationFieldsGenerator());
     runTimeGenerators.add(new MapMappingGenerator());
@@ -237,7 +239,8 @@ public final class ClassMapBuilder {
           String propertyName = property.getName();
           if (mapping != null) {
             String pairName = mapping.value().trim();
-            GeneratorUtils.addGenericMapping(classMap, configuration, propertyName, pairName.isEmpty() ? propertyName : pairName);
+            GeneratorUtils.addGenericMapping(MappingType.GETTER_TO_SETTER, classMap, configuration,
+                    propertyName, pairName.isEmpty() ? propertyName : pairName);
           }
         }
       }
@@ -251,7 +254,8 @@ public final class ClassMapBuilder {
           String propertyName = property.getName();
           if (mapping != null) {
             String pairName = mapping.value().trim();
-            GeneratorUtils.addGenericMapping(classMap, configuration, pairName.isEmpty() ? propertyName : pairName, propertyName);
+            GeneratorUtils.addGenericMapping(MappingType.GETTER_TO_SETTER, classMap, configuration,
+                    pairName.isEmpty() ? propertyName : pairName, propertyName);
           }
         }
       }
@@ -274,7 +278,8 @@ public final class ClassMapBuilder {
           String fieldName = field.getName();
           if (mapping != null) {
             String pairName = mapping.value().trim();
-            addFieldMapping(classMap, configuration, fieldName, pairName.isEmpty() ? fieldName : pairName);
+            GeneratorUtils.addGenericMapping(MappingType.FIELD_TO_FIELD, classMap, configuration,
+                    fieldName, pairName.isEmpty() ? fieldName : pairName);
           }
         }
         srcType = srcType.getSuperclass();
@@ -287,7 +292,8 @@ public final class ClassMapBuilder {
           String fieldName = field.getName();
           if (mapping != null) {
             String pairName = mapping.value().trim();
-            addFieldMapping(classMap, configuration, pairName.isEmpty() ? fieldName : pairName, fieldName);
+            GeneratorUtils.addGenericMapping(MappingType.FIELD_TO_FIELD, classMap, configuration,
+                    pairName.isEmpty() ? fieldName : pairName, fieldName);
           }
         }
         destType = destType.getSuperclass();
@@ -295,22 +301,5 @@ public final class ClassMapBuilder {
       
       return false;
     }
-  }
-
-  private static void addFieldMapping(ClassMap classMap, Configuration configuration, String srcName, String destName) {
-    FieldMap fieldMap = new GenericFieldMap(classMap);
-
-    DozerField sourceField = new DozerField(srcName, null);
-    DozerField destField = new DozerField(destName, null);
-
-    sourceField.setAccessible(true);
-    destField.setAccessible(true);
-
-    fieldMap.setSrcField(sourceField);
-    fieldMap.setDestField(destField);
-
-    // add CopyByReferences per defect #1728159
-    MappingUtils.applyGlobalCopyByReference(configuration, fieldMap, classMap);
-    classMap.addFieldMapping(fieldMap);
   }
 }

--- a/core/src/main/java/org/dozer/classmap/DozerClass.java
+++ b/core/src/main/java/org/dozer/classmap/DozerClass.java
@@ -131,8 +131,8 @@ public class DozerClass {
     return getMapGetMethod() != null || getMapSetMethod() != null;
   }
 
-  public Boolean isAccesible() {
-    return accessible;
+  public boolean isAccessible() {
+    return accessible != null && accessible;
   }
 
   public void setAccessible(Boolean accessible) {

--- a/core/src/main/java/org/dozer/classmap/generator/BeanMappingGenerator.java
+++ b/core/src/main/java/org/dozer/classmap/generator/BeanMappingGenerator.java
@@ -58,7 +58,7 @@ public class BeanMappingGenerator implements ClassMapBuilder.ClassMappingGenerat
         continue;
       }
 
-      GeneratorUtils.addGenericMapping(classMap, configuration, fieldName, fieldName);
+      GeneratorUtils.addGenericMapping(MappingType.GETTER_TO_SETTER, classMap, configuration, fieldName, fieldName);
     }
     return false;
   }

--- a/core/src/main/java/org/dozer/classmap/generator/ClassLevelFieldMappingGenerator.java
+++ b/core/src/main/java/org/dozer/classmap/generator/ClassLevelFieldMappingGenerator.java
@@ -1,0 +1,97 @@
+package org.dozer.classmap.generator;
+
+import org.dozer.classmap.ClassMap;
+import org.dozer.classmap.ClassMapBuilder;
+import org.dozer.classmap.Configuration;
+import org.dozer.fieldmap.FieldMap;
+import org.dozer.util.CollectionUtils;
+
+import java.lang.reflect.Field;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Provides default field mappings when either the source class, destination class or both
+ * classes have been declared field accessible e.g. with {@code is-accessible="true"}.
+ */
+public class ClassLevelFieldMappingGenerator implements ClassMapBuilder.ClassMappingGenerator {
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean accepts(ClassMap classMap) {
+        return srcClassIsAccessible(classMap) || destClassIsAccessible(classMap);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean apply(ClassMap classMap, Configuration configuration) {
+        BeanMappingGenerator.BeanFieldsDetector beanFieldsDetector = new JavaBeanFieldsDetector();
+
+        Set<String> destFieldNames = getDeclaredFieldNames(classMap.getDestClassToMap());
+        Set<String> destWritablePropertyNames = beanFieldsDetector.getWritableFieldNames(classMap.getDestClassToMap());
+        Set<String> srcFieldNames = getDeclaredFieldNames(classMap.getSrcClassToMap());
+        Set<String> srcReadablePropertyNames = beanFieldsDetector.getReadableFieldNames(classMap.getSrcClassToMap());
+
+        Set<String> matchingUnmappedFields = getMatchingUnmappedFieldNames(
+                classMap.getFieldMaps(), srcFieldNames, destFieldNames);
+
+        for (String mutualFieldName : matchingUnmappedFields) {
+            mapFieldAppropriately(classMap, configuration, mutualFieldName, destWritablePropertyNames, srcReadablePropertyNames);
+        }
+
+        return false;
+    }
+
+    private void mapFieldAppropriately(ClassMap classMap, Configuration configuration,
+                                       String mutualFieldName, Set<String> destWritablePropertyNames,
+                                       Set<String> srcReadablePropertyNames) {
+        MappingType mappingType;
+
+        if (!destClassIsAccessible(classMap) && destWritablePropertyNames.contains(mutualFieldName)) {
+            mappingType = MappingType.FIELD_TO_SETTER;
+        } else if (!srcClassIsAccessible(classMap) && srcReadablePropertyNames.contains(mutualFieldName)) {
+            mappingType = MappingType.GETTER_TO_FIELD;
+        } else {
+            mappingType = MappingType.FIELD_TO_FIELD;
+        }
+
+        GeneratorUtils.addGenericMapping(mappingType, classMap, configuration,
+                mutualFieldName, mutualFieldName);
+    }
+
+    private Set<String> getDeclaredFieldNames(Class<?> srcType) {
+        Set<String> declaredFieldNames = new HashSet<String>();
+
+        do {
+            for (Field field : srcType.getDeclaredFields()) {
+                declaredFieldNames.add(field.getName());
+            }
+
+            srcType = srcType.getSuperclass();
+        } while(srcType != null);
+
+        return declaredFieldNames;
+    }
+
+    private Set<String> getMatchingUnmappedFieldNames(List<FieldMap> fieldMaps,
+                                                      Set<String> srcFieldNames,
+                                                      Set<String> destFieldNames) {
+
+        for (FieldMap fieldMap : fieldMaps) {
+            // Remove all already mapped
+            srcFieldNames.remove(fieldMap.getSrcFieldName());
+            destFieldNames.remove(fieldMap.getDestFieldName());
+        }
+
+        return new HashSet<String>(CollectionUtils.intersection(srcFieldNames, destFieldNames));
+    }
+
+    private boolean destClassIsAccessible(ClassMap classMap) {
+        return classMap.getDestClass() != null && classMap.getDestClass().isAccessible();
+    }
+
+    private boolean srcClassIsAccessible(ClassMap classMap) {
+        return classMap.getSrcClass() != null && classMap.getSrcClass().isAccessible();
+    }
+}

--- a/core/src/main/java/org/dozer/classmap/generator/GeneratorUtils.java
+++ b/core/src/main/java/org/dozer/classmap/generator/GeneratorUtils.java
@@ -43,14 +43,28 @@ public final class GeneratorUtils {
     return false;
   }
 
-  public static void addGenericMapping(ClassMap classMap, Configuration configuration, String srcName, String destName) {
-    FieldMap fieldMap = new GenericFieldMap(classMap);
+  public static void addGenericMapping(MappingType mappingType, ClassMap classMap,
+                                       Configuration configuration, String srcName, String destName) {
+      FieldMap fieldMap = new GenericFieldMap(classMap);
+      DozerField srcField = new DozerField(srcName, null);
+      DozerField destField = new DozerField(destName, null);
+      fieldMap.setSrcField(srcField);
+      fieldMap.setDestField(destField);
 
-    fieldMap.setSrcField(new DozerField(srcName, null));
-    fieldMap.setDestField(new DozerField(destName, null));
+      switch (mappingType) {
+          case FIELD_TO_FIELD:
+              srcField.setAccessible(true);
+              destField.setAccessible(true);
+              break;
+          case FIELD_TO_SETTER:
+              srcField.setAccessible(true);
+              break;
+          case GETTER_TO_SETTER:
+              break;
+      }
 
-    // add CopyByReferences per defect #1728159
-    MappingUtils.applyGlobalCopyByReference(configuration, fieldMap, classMap);
-    classMap.addFieldMapping(fieldMap);
+      // add CopyByReferences per defect #1728159
+      MappingUtils.applyGlobalCopyByReference(configuration, fieldMap, classMap);
+      classMap.addFieldMapping(fieldMap);
   }
 }

--- a/core/src/main/java/org/dozer/classmap/generator/MappingType.java
+++ b/core/src/main/java/org/dozer/classmap/generator/MappingType.java
@@ -1,0 +1,15 @@
+package org.dozer.classmap.generator;
+
+/**
+ * Defines the mapping style to use between the source and target objects.
+ */
+public enum MappingType {
+    /** Map from source field to target field */
+    FIELD_TO_FIELD,
+    /** Map from source field to target setter */
+    FIELD_TO_SETTER,
+    /** Map from source getter to target field */
+    GETTER_TO_FIELD,
+    /** Map from source getter to target setter */
+    GETTER_TO_SETTER
+}

--- a/core/src/main/java/org/dozer/fieldmap/FieldMap.java
+++ b/core/src/main/java/org/dozer/fieldmap/FieldMap.java
@@ -32,7 +32,6 @@ import org.dozer.util.MappingUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.lang.reflect.Method;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
@@ -268,11 +267,7 @@ public abstract class FieldMap implements Cloneable {
     if (fieldLevel != null) {
       return fieldLevel;
     } else {
-      Boolean classLevel = clazz.isAccesible();
-      if (classLevel == null) {
-        return false;
-      }
-      return classLevel;
+      return clazz.isAccessible();
     }
   }
 

--- a/core/src/main/java/org/dozer/util/MappingUtils.java
+++ b/core/src/main/java/org/dozer/util/MappingUtils.java
@@ -28,16 +28,7 @@ import org.dozer.fieldmap.DozerField;
 import org.dozer.fieldmap.FieldMap;
 
 import java.lang.reflect.Array;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.LinkedHashSet;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 import static org.dozer.util.DozerConstants.BASE_CLASS;
 
@@ -167,11 +158,11 @@ public final class MappingUtils {
     destination.setSrcClass(new DozerClass(source.getDestClassName(), source.getDestClassToMap(), source.getDestClassBeanFactory(),
         source.getDestClassBeanFactoryId(), source.getDestClassMapGetMethod(), source.getDestClassMapSetMethod(),
             source.getDestClass().getCreateMethod(),
-            source.isDestMapNull(), source.isDestMapEmptyString(), source.getDestClass().isAccesible()));
+            source.isDestMapNull(), source.isDestMapEmptyString(), source.getDestClass().isAccessible()));
     destination.setDestClass(new DozerClass(source.getSrcClassName(), source.getSrcClassToMap(), source.getSrcClassBeanFactory(),
         source.getSrcClassBeanFactoryId(), source.getSrcClassMapGetMethod(), source.getSrcClassMapSetMethod(),
             source.getSrcClass().getCreateMethod(),
-            source.isSrcMapNull(), source.isSrcMapEmptyString(), source.getSrcClass().isAccesible()));
+            source.isSrcMapNull(), source.isSrcMapEmptyString(), source.getSrcClass().isAccessible()));
     destination.setType(source.getType());
     destination.setWildcard(source.isWildcard());
     destination.setTrimStrings(source.isTrimStrings());

--- a/core/src/test/java/org/dozer/fieldmap/FieldMapTest.java
+++ b/core/src/test/java/org/dozer/fieldmap/FieldMapTest.java
@@ -73,7 +73,7 @@ public class FieldMapTest extends AbstractDozerTest {
 
   @Test
   public void shouldBeAccessible_ClassLevel() {
-    when(classMap.getDestClass().isAccesible()).thenReturn(Boolean.TRUE);
+    when(classMap.getDestClass().isAccessible()).thenReturn(Boolean.TRUE);
     when(field.isAccessible()).thenReturn(Boolean.FALSE);
 
     assertFalse(fieldMap.isDestFieldAccessible());
@@ -81,7 +81,7 @@ public class FieldMapTest extends AbstractDozerTest {
 
   @Test
   public void shouldBeAccessible_Both() {
-    when(classMap.getDestClass().isAccesible()).thenReturn(Boolean.TRUE);
+    when(classMap.getDestClass().isAccessible()).thenReturn(Boolean.TRUE);
     when(field.isAccessible()).thenReturn(Boolean.TRUE);
 
     assertTrue(fieldMap.isDestFieldAccessible());
@@ -89,7 +89,7 @@ public class FieldMapTest extends AbstractDozerTest {
 
   @Test
   public void shouldBeAccessible_FieldLevel() {
-    when(classMap.getDestClass().isAccesible()).thenReturn(Boolean.FALSE);
+    when(classMap.getDestClass().isAccessible()).thenReturn(Boolean.FALSE);
     when(field.isAccessible()).thenReturn(Boolean.TRUE);
 
     assertTrue(fieldMap.isDestFieldAccessible());
@@ -97,7 +97,7 @@ public class FieldMapTest extends AbstractDozerTest {
 
   @Test
   public void shouldBeAccessible_Override() {
-    when(classMap.getDestClass().isAccesible()).thenReturn(Boolean.TRUE);
+    when(classMap.getDestClass().isAccessible()).thenReturn(Boolean.TRUE);
     when(field.isAccessible()).thenReturn(Boolean.FALSE);
 
     assertFalse(fieldMap.isDestFieldAccessible());
@@ -105,7 +105,7 @@ public class FieldMapTest extends AbstractDozerTest {
 
   @Test
   public void shouldBeAccessible_Null() {
-    when(classMap.getDestClass().isAccesible()).thenReturn(null);
+    when(classMap.getDestClass().isAccessible()).thenReturn(false);
     when(field.isAccessible()).thenReturn(Boolean.TRUE);
 
     assertTrue(fieldMap.isDestFieldAccessible());
@@ -113,7 +113,7 @@ public class FieldMapTest extends AbstractDozerTest {
 
   @Test
   public void shouldBeAccessible_FieldLevelNull() {
-    when(classMap.getDestClass().isAccesible()).thenReturn(Boolean.TRUE);
+    when(classMap.getDestClass().isAccessible()).thenReturn(Boolean.TRUE);
     when(field.isAccessible()).thenReturn(null);
 
     assertTrue(fieldMap.isDestFieldAccessible());
@@ -121,7 +121,7 @@ public class FieldMapTest extends AbstractDozerTest {
 
   @Test
   public void shouldBeAccessible_Default() {
-    when(classMap.getDestClass().isAccesible()).thenReturn(null);
+    when(classMap.getDestClass().isAccessible()).thenReturn(false);
     when(field.isAccessible()).thenReturn(null);
 
     assertFalse(fieldMap.isDestFieldAccessible());

--- a/core/src/test/java/org/dozer/functional_tests/ClassLevelIsAccessibleTest.java
+++ b/core/src/test/java/org/dozer/functional_tests/ClassLevelIsAccessibleTest.java
@@ -1,0 +1,129 @@
+package org.dozer.functional_tests;
+
+import org.dozer.Mapping;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests for situations when the entire class has been declared as accessible
+ * (is-accessible=true).
+ */
+public class ClassLevelIsAccessibleTest extends AbstractFunctionalTest {
+    private final String FIELD_VALUE = "someValue";
+
+    @Override
+    @Before
+    public void setUp() throws Exception {
+        mapper = getMapper("classLevelIsAccessible.xml");
+    }
+
+    @Test
+    public void testClassLevelMappingOfField_FirstToSecond() {
+        First source = new First();
+        source.someField = FIELD_VALUE;
+        source.another = 2;
+
+        Second target = mapper.map(source, Second.class);
+
+        assertThat(target.someField, equalTo(FIELD_VALUE));
+    }
+
+    @Test
+    public void testClassLevelMappingOfField_SecondToFirst() {
+        Second source = new Second();
+        source.someField = FIELD_VALUE;
+
+        First target = mapper.map(source, First.class);
+
+        assertThat(target.someField, equalTo(FIELD_VALUE));
+        assertThat(target.another, equalTo(source.another));
+    }
+
+    @Test
+    public void testExplicitXMLFieldMappingOverridesDefaultFieldMapping() {
+        First source = new First();
+        source.someField = FIELD_VALUE;
+
+        CustomFieldMapped target = mapper.map(source, CustomFieldMapped.class);
+
+        assertThat(target.someField, nullValue());
+        assertThat(target.otherField, equalTo(FIELD_VALUE));
+    }
+
+    @Test
+    public void testExplicitAnnotationMappingOverridesDefaultFieldMapping() {
+        AnnotationMapped source = new AnnotationMapped();
+        source.aField = FIELD_VALUE;
+        source.bField = 42;
+
+        First target = mapper.map(source, First.class);
+
+        assertThat(target.someField, equalTo(source.aField));
+        assertThat(target.another, equalTo(source.bField));
+    }
+
+    @Test
+    public void testSetterUsedWhenMappingToNonAccessibleClass() {
+        First source = new First();
+        source.someField = FIELD_VALUE;
+
+        BeanClass target = mapper.map(source, BeanClass.class);
+
+        assertThat(target.setterInvoked, is(true));
+    }
+
+    @Test
+    public void testGetterUsedWhenMappingFromNonAccessibleClass() {
+        BeanClass source = new BeanClass();
+        source.someField = FIELD_VALUE;
+
+        mapper.map(source, First.class);
+
+        assertThat(source.getterInvoked, is(true));
+    }
+
+    public static class First {
+        private String someField;
+        private int another;
+    }
+
+    public static class Second {
+        private String someField;
+        private final int another = 8;
+    }
+
+    public static class CustomFieldMapped {
+        @SuppressWarnings("unused")
+        private String someField;
+        @SuppressWarnings("unused")
+        private String otherField;
+    }
+
+    public static class AnnotationMapped {
+        @Mapping("someField")
+        private String aField;
+        @Mapping("another")
+        private int bField;
+    }
+
+    public static class BeanClass {
+        private String someField;
+        private boolean setterInvoked;
+        private boolean getterInvoked;
+
+        @SuppressWarnings("unused")
+        public String getSomeField() {
+            getterInvoked = true;
+            return someField;
+        }
+
+        @SuppressWarnings("unused")
+        public void setSomeField(String someField) {
+            setterInvoked = true;
+            this.someField = someField;
+        }
+    }
+}

--- a/core/src/test/resources/classLevelIsAccessible.xml
+++ b/core/src/test/resources/classLevelIsAccessible.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2005-2013 Dozer Project
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<mappings xmlns="http://dozer.sourceforge.net"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://dozer.sourceforge.net http://dozer.sourceforge.net/schema/beanmapping.xsd">
+
+    <mapping>
+        <class-a is-accessible="true">org.dozer.functional_tests.ClassLevelIsAccessibleTest$First</class-a>
+        <class-b is-accessible="true">org.dozer.functional_tests.ClassLevelIsAccessibleTest$Second</class-b>
+    </mapping>
+
+    <mapping>
+        <class-a is-accessible="true">org.dozer.functional_tests.ClassLevelIsAccessibleTest$First</class-a>
+        <class-b is-accessible="true">org.dozer.functional_tests.ClassLevelIsAccessibleTest$CustomFieldMapped</class-b>
+        <field>
+            <a>someField</a>
+            <b>otherField</b>
+        </field>
+    </mapping>
+
+    <mapping>
+        <class-a is-accessible="true">org.dozer.functional_tests.ClassLevelIsAccessibleTest$First</class-a>
+        <class-b>org.dozer.functional_tests.ClassLevelIsAccessibleTest$BeanClass</class-b>
+    </mapping>
+
+    <mapping>
+        <class-a>org.dozer.functional_tests.ClassLevelIsAccessibleTest$First</class-a>
+        <class-b is-accessible="true">org.dozer.functional_tests.ClassLevelIsAccessibleTest$AnnotationMapped</class-b>
+    </mapping>
+</mappings>


### PR DESCRIPTION
Resolves issue #23 (Class level is-accessible doesn't work). Logic:

Both class A and B declared accessible: Map from matching fields in A to fields in B
Only class A declared accessible: Map from matching fields in A to matching properties in B
Explicit mappings (via @Mapping or XML) override these default is-accessible="true" mappings
