### PR TITLE
Update MappingProcessor.java

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -23,12 +23,13 @@
   <parent>
     <groupId>net.sf.dozer</groupId>
     <artifactId>dozer-parent</artifactId>
-    <version>5.5.1.dorsale</version>
+    <version>5.5.1</version>
   </parent>
 
   <artifactId>dozer</artifactId>
   <packaging>jar</packaging>
   <name>Dozer</name>
+  <version>5.5.1.dorsale</version>
 
   <properties>
     <osgi.version>4.3.0</osgi.version>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>net.sf.dozer</groupId>
     <artifactId>dozer-parent</artifactId>
-    <version>5.5.1</version>
+    <version>5.5.1.dorsale</version>
   </parent>
 
   <artifactId>dozer</artifactId>

--- a/core/src/main/java/org/dozer/MappingProcessor.java
+++ b/core/src/main/java/org/dozer/MappingProcessor.java
@@ -1087,7 +1087,8 @@ public class MappingProcessor implements Mapper {
       if (CollectionUtils.isList(result.getClass()) || CollectionUtils.isArray(result.getClass())
           || CollectionUtils.isSet(result.getClass()) || MappingUtils.isSupportedMap(result.getClass())) {
         if (!CollectionUtils.isList(destFieldType) && !CollectionUtils.isArray(destFieldType)
-            && !CollectionUtils.isSet(destFieldType) && !MappingUtils.isSupportedMap(destFieldType)) {
+            && !CollectionUtils.isSet(destFieldType) && !MappingUtils.isSupportedMap(destFieldType)
+            && !CollectionUtils.isCollection(destFieldType)) {
           // this means the getXX field is a List but we are actually trying to
           // map one of its elements
           result = null;


### PR DESCRIPTION
MappingProcessor.getExistingValue returning null when destination is a Collection #187

In the check to make sure that we are not in the list by checking the destFieldType it should be added that the destFieldType can be a Collection. e.g. CollectionUtils.isCollection.
Otherwise, this method returns null, when it should return the collection. (As it does for the Lists)
