### PR TITLE
Using default dozer configuration is not worth logging a warning

### DIFF
--- a/core/src/main/java/org/dozer/config/GlobalSettings.java
+++ b/core/src/main/java/org/dozer/config/GlobalSettings.java
@@ -115,7 +115,7 @@ public class GlobalSettings {
     DozerClassLoader classLoader = BeanContainer.getInstance().getClassLoader();
     URL url = classLoader.loadResource(propFileName);
     if (url == null) {
-      log.warn("Dozer configuration file not found: {}.  Using defaults for all Dozer global properties.", propFileName);
+      log.info("Dozer configuration file not found: {}.  Using defaults for all Dozer global properties.", propFileName);
       return;
     } else {
       log.info("Using URL [{}] for Dozer global property configuration", url);


### PR DESCRIPTION
If you want to monitor a log file of an application in production you would define this basic rules:
ERROR: Severe problem. Immediately get a person of charge out of his bed and let him fix the problem.
WARNING: Write an email to the responsible person and let him fix the problem within a day.

Because the information "using defaults" is not really a production problem, I would recommend to only log at information level.
