### PR TITLE
XmlDateConverter: A DozerConverter for date-time strings.

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -28,6 +28,7 @@
 
   <artifactId>dozer</artifactId>
   <packaging>jar</packaging>
+  <version>5.5.2-SNAPSHOT</version>
   <name>Dozer</name>
 
   <properties>
@@ -274,21 +275,33 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>jaxb2-maven-plugin</artifactId>
-        <version>1.3.1</version>
+        <groupId>org.jvnet.jaxb2.maven2</groupId>
+        <artifactId>maven-jaxb2-plugin</artifactId>
+        <version>0.12.3</version>
         <executions>
           <execution>
             <phase>generate-test-sources</phase>
             <goals>
-              <goal>xjc</goal>
+              <goal>generate</goal>
             </goals>
           </execution>
         </executions>
         <configuration>
+          <args>
+            <arg>-no-header</arg>
+            <arg>-Xsetters</arg>
+            <arg>-Xsetters-mode=direct</arg>
+          </args>
           <schemaDirectory>src/test/xsd/jaxb</schemaDirectory>
-          <packageName>org.dozer.vo.jaxb.employee</packageName>
-          <outputDirectory>target/jaxb-sources</outputDirectory>
+          <generatePackage>org.dozer.vo.jaxb.employee</generatePackage>
+          <generateDirectory>target/jaxb-sources</generateDirectory>
+          <plugins>
+            <plugin>
+              <groupId>org.jvnet.jaxb2_commons</groupId>
+              <artifactId>jaxb2-basics</artifactId>
+              <version>0.9.2</version>
+            </plugin>
+          </plugins>
         </configuration>
       </plugin>
       <plugin>

--- a/core/src/main/java/org/dozer/converters/custom/XmlDateConverter.java
+++ b/core/src/main/java/org/dozer/converters/custom/XmlDateConverter.java
@@ -1,0 +1,386 @@
+/*
+ * Copyright 2005-2010 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dozer.converters.custom;
+
+import java.text.SimpleDateFormat;
+import java.util.GregorianCalendar;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.TimeZone;
+import java.util.regex.Pattern;
+
+import javax.xml.bind.JAXBElement;
+import javax.xml.datatype.DatatypeConfigurationException;
+import javax.xml.datatype.DatatypeFactory;
+import javax.xml.datatype.XMLGregorianCalendar;
+
+import org.dozer.DozerConverter;
+import org.dozer.MappingException;
+import org.dozer.converters.ConversionException;
+import org.dozer.converters.XMLGregorianCalendarConverter;
+import org.dozer.loader.api.FieldsMappingOption;
+import org.dozer.loader.api.FieldsMappingOptions;
+
+/**
+ * A Dozer Converter to convert a Date-like object to an {@link XMLGregorianCalendar} object.
+ * Provides a helper method to create a {@link FieldsMappingOption}. When possible uses 
+ * {@link XMLGregorianCalendarConverter} to convert Date, Calendar, XMLGregorianCalendar, 
+ * 'date literal' or millisecond values; otherwise, the source is interpreted as a arbitrary
+ * date-time literal and matched to a best possible SimpleDateFormat pattern.
+ * 
+ * For example, to create a {@link FieldsMappingOption} to map an ISO8601 formatted date-time 
+ * literal to an {@link XMLGregorianCalendarConverter}, use this:
+ * 
+ * <code>XmlDateConverter.convertXmlDate(XmlDateConverter.ISO8601)</code>
+ * 
+ * IMPORTANT: Initialize with the longest pattern that works for your date time values 
+ *            to achieve the best probable conversion. The recommended pattern is ISO8601.
+ * 
+ * The configured pattern is used to parse literal date-time strings. If the parse fails,
+ * the default exception handler looks for a pattern that matche the literal value. This
+ * behavior can be disabled using the 'strict' property.  
+ * 
+ * @author Rick O'Sullivan
+ */
+public class XmlDateConverter extends DozerConverter<Object, XMLGregorianCalendar>
+{
+	// @see java.text.SimpleDateFormat
+	//   OneLetterISO8601TimeZone   is   'X' for 'Sign TwoDigitHours' (ex: -05) or Z.
+	//   TwoLetterISO8601TimeZone   is  'XX' for 'Sign TwoDigitHours Minutes' (ex: -0500) or Z.
+	//   ThreeLetterISO8601TimeZone is 'XXX' for 'Sign TwoDigitHours : Minutes' (ex: -05:00) or Z.
+	public static final String ISO8601       = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX";
+	public static final String ISO8601SSSXXX = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX";
+	public static final String ISO8601SSSXX  = "yyyy-MM-dd'T'HH:mm:ss.SSSXX";
+	public static final String ISO8601SSSX   = "yyyy-MM-dd'T'HH:mm:ss.SSSX";
+	public static final String ISO8601XXX    = "yyyy-MM-dd'T'HH:mm:ssXXX";
+	public static final String ISO8601XX     = "yyyy-MM-dd'T'HH:mm:ssXX";
+	public static final String ISO8601X      = "yyyy-MM-dd'T'HH:mm:ssX";
+	public static final String ISO8601SSSZ   = "yyyy-MM-dd'T'HH:mm:ss.SSSZ";
+	public static final String ISO8601Z      = "yyyy-MM-dd'T'HH:mm:ssZ";
+	
+	/**
+	 * Get parameter containing a {@link SimpleDateFormat} pattern.
+	 * @return a date time pattern.
+	 */
+	@Override
+	public String getParameter()
+	{
+		try
+		{
+			return super.getParameter();
+		}
+		catch ( IllegalStateException ex)
+		{
+			setParameter(ISO8601);
+			return super.getParameter();
+		}
+	}
+	
+	private boolean strict;
+	/**
+	 * Is strict pattern lookup active.
+	 * @return True when pattern lookup is off; otherwise false.
+	 */
+	public boolean isStrict() {
+		return strict;
+	}
+	/**
+	 * Set strict pattern lookup behavior.
+	 * @param strict True to prevent pattern lookups.
+	 */
+	public void setStrict(boolean strict) {
+		this.strict = strict;
+	}
+
+	private XMLGregorianCalendarConverter converter;
+	protected XMLGregorianCalendarConverter getConverter()
+	{
+		if ( converter == null )
+			converter = new XMLGregorianCalendarConverter(new SimpleDateFormat(getParameter()));
+		return converter;
+	}
+	protected void setConverter(XMLGregorianCalendarConverter converter)
+	{
+		this.converter = converter;
+	}
+
+	private static DatatypeFactory datatypeFactory;
+	protected static DatatypeFactory getDatatypeFactory() 
+	{
+		try
+		{
+			if ( datatypeFactory == null )
+				datatypeFactory = DatatypeFactory.newInstance();
+			return datatypeFactory;
+		}
+		catch (DatatypeConfigurationException dce)
+		{
+			throw new MappingException(dce);
+		}
+	}
+	
+	/**
+	 * Create a XMLGregorianCalendar instance for the current time
+	 * in the default time zone with the default locale.
+	 * 
+	 * @return a current MLGregorianCalendar instance.
+	 */
+	public static XMLGregorianCalendar now()
+	{
+		return now(null);
+	}
+	
+	/**
+	 * Create a XMLGregorianCalendar instance for the current time
+	 * in the specified time zone with the default locale.
+	 * 
+	 * @param tz the specified time zone.
+	 * 
+	 * @return a current MLGregorianCalendar instance.
+	 */
+	public static XMLGregorianCalendar now(TimeZone tz)
+	{
+		GregorianCalendar gc = (tz == null ) ? new GregorianCalendar() : new GregorianCalendar(tz);
+		return getDatatypeFactory().newXMLGregorianCalendar(gc);
+	}
+	
+	/**
+	 * Default constructor with Object and XMLGregorianCalendar prototypes.
+	 */
+	public XmlDateConverter()
+	{
+		super(Object.class, XMLGregorianCalendar.class);
+	}
+
+	/**
+	 * Defines two types, which will take part in the transformation. As Dozer supports
+	 * bi-directional mapping it is not known which of the classes is source and
+	 * which is destination. It will be decided in runtime.
+	 *
+	 * @param prototypeA First transformation type.
+	 * @param prototypeB Second transformation type.
+	 */
+	public XmlDateConverter(Class<Object> prototypeA, Class<XMLGregorianCalendar> prototypeB)
+	{
+		super(prototypeA, prototypeB);
+	}
+
+	/**
+	 * Converts the a date-like source field into a XMLGregorianCalendar field.
+	 *
+	 * @param source the field containing a date-like value.
+	 * 
+	 * @return an instance of XMLGregorianCalendar.
+	 */
+	@Override
+	public XMLGregorianCalendar convertTo(Object source)
+	{
+		return convertTo(source, null);
+	}
+	
+	/**
+	 * Converts the a date-like source field into a XMLGregorianCalendar field.
+	 *
+	 * @param source      the field containing a date-like value.
+	 * @param destination the current value of the XMLGregorianCalendar field (or null)
+	 * 
+	 * @return an instance of XMLGregorianCalendar.
+	 * 
+	 * @see org.dozer.DozerConverter#convertTo(Object, Object)
+	 */
+	@Override
+	public XMLGregorianCalendar convertTo(Object source, XMLGregorianCalendar destination)
+	{
+		try
+		{
+			// First, attempt to convert the source using XMLGregorianCalendarConverter. The 
+			// XMLGregorianCalendarConverter attempts to converts Date, Calendar, XMLGregorianCalendar,
+			// 'date literal' or milliseconds to an instance of XMLGregorianCalendar.
+			//
+			// Notes:
+			//
+			// The format for the date literal conversion is provided by this instances Parameter property 
+			// which is a SimpleDateFormat pattern describing the date and time.
+			//
+			// The number of milliseconds since the standard base time (January 1, 1970, 00:00:00 GMT)
+			//
+			// XMLGregorianCalendarConverter is a org.apache.commons.beanutils.Converter while this class 
+			// implements a org.dozer.CustomConverter which can be used to create a FieldsMappingOption
+			// with FieldsMappingOptions.customConverter(...). 
+			return (source == null) ? null :(XMLGregorianCalendar) getConverter().convert(XMLGregorianCalendar.class, source);
+		}
+		catch ( ConversionException cex)
+		{
+			if ( !isStrict() )
+			{
+				// The first attempt may have been unable to parse the source object using specified date 
+				// format or unable to determine time in milliseconds of source object. Let's try to find
+				// a better SimpleDateFormat pattern.
+				//
+				// Attempt to lookup the SimpleDateFormat pattern from the source value.
+				String dateValue = dateTimeLiteral(source);
+				String dateFormat = XmlDateConverter.rawPattern(dateValue);
+				if ( dateFormat != null )
+				{
+					// Found a possible SimpleDateFormat pattern, reset the Parameter and Converter
+					// properties and try again.
+					String originalDateFormat = getParameter();
+					try
+					{
+						setParameter(dateFormat);
+						setConverter(null);
+						return (XMLGregorianCalendar) getConverter().convert(XMLGregorianCalendar.class, dateValue);
+					}
+					finally
+					{
+						setParameter(originalDateFormat);
+						setConverter(null);
+					}
+				}
+			}
+			throw cex;
+		}
+	}
+
+	@Override
+	public String convertFrom(XMLGregorianCalendar source) 
+	{
+		return convertFrom(source, null);
+	}
+	
+	/**
+	 * Converts a XMLGregorianCalendar source field to the destination field.
+	 *
+	 * @param source      the XMLGregorianCalendar value of the source field
+	 * @param destination the current value of the destination field (or null)
+	 * 
+	 * @return the resulting XML formatted value for the destination field.
+	 */
+	@Override
+	public String convertFrom(XMLGregorianCalendar source, Object destination) 
+	{
+		return (source != null) ? source.toXMLFormat() : null;
+	}
+	
+	/**
+	 * Helper method to create a field option for the default XML date format.
+	 * 
+	 * @return a field mapping option for ISO8601 date literal.
+	 */
+	public static FieldsMappingOption convertXmlDate()
+	{
+		return convertXmlDate(ISO8601);
+	}
+	
+	/**
+	 * Helper method to create a field option for the specified date format.
+	 * 
+	 * @param the SimpleDateFormat pattern describing the date and time format.
+	 * 
+	 * @return a field mapping option for a custom date literal.
+	 */
+	public static FieldsMappingOption convertXmlDate(String dateFormat)
+	{
+		return FieldsMappingOptions.customConverter(XmlDateConverter.class, dateFormat);
+	}
+
+	/**
+	 * Lookup a {@link SimpleDateFormat} pattern that best matches the given date value.
+	 * 
+	 * @param dateValue a literal representation of a date value.
+	 * 
+	 * @return A pattern matching the date value or null for no match.
+	 */
+	public static String pattern(String dateValue)
+	{
+		return rawPattern(dateTimeLiteral(dateValue));
+	}
+	
+	private static Pattern YYYY_MM = Pattern.compile("^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}.*");
+	
+	// Convert source object into possible date time literal.
+	private static String dateTimeLiteral(Object source)
+	{
+		String dateTimeLiteral = "";
+		
+		// Unwrap JAXBElement values, etc.
+		if ( source instanceof JAXBElement)
+		{
+			@SuppressWarnings("rawtypes")
+			JAXBElement je = (JAXBElement) source;
+			dateTimeLiteral = (je.getValue() != null ) ? je.getValue().toString() : "";
+		}
+		else if ( source != null )
+			dateTimeLiteral = source.toString();
+
+		// Prefer 'T' syntax over ' ' syntax.
+		if ( YYYY_MM.matcher(dateTimeLiteral).matches() )
+			dateTimeLiteral = dateTimeLiteral.replaceFirst(" ", "T");
+		
+		// Replace any Zulu suffix with ISO8601 zero hour and minutes.
+		return dateTimeLiteral.replaceAll("[zZ]$", "+00:00");
+	}
+	
+	// Lookup a {@link SimpleDateFormat} pattern that best matches the given raw date value.
+	private static String rawPattern(String dateValue)
+	{
+		String timePattern = null;
+		for ( Pattern pattern : PATTERNS.keySet() )
+		{
+			if ( pattern.matcher(dateValue).matches() )
+			{
+				timePattern = (String) PATTERNS.get(pattern);
+				break;
+			}
+		}
+		return timePattern;
+	}
+	
+	// Represents a map of compiled regex patterns in decreasing order of complexity.
+	private static final Map<Pattern, String> PATTERNS = new LinkedHashMap<Pattern, String>();
+	static
+	{
+		PATTERNS.put(Pattern.compile("^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\\.[0-9]+[-+][0-9]{2}:[0-9]{2}$"), "yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
+		PATTERNS.put(Pattern.compile("^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}[-+][0-9]{2}:[0-9]{2}$"), "yyyy-MM-dd'T'HH:mm:ssXXX");
+		PATTERNS.put(Pattern.compile("^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}[-+][0-9]{2}:[0-9]{2}$"), "yyyy-MM-dd'T'HH:mmXXX");
+		PATTERNS.put(Pattern.compile("^[0-9]{4}-[0-9]{2}-[0-9]{2}[-+][0-9]{2}:[0-9]{2}$"), "yyyy-MM-ddXXX");
+		
+		PATTERNS.put(Pattern.compile("^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\\.[0-9]+[-+][0-9]{4}$"), "yyyy-MM-dd'T'HH:mm:ss.SSSXX");
+		PATTERNS.put(Pattern.compile("^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}[-+][0-9]{4}$"), "yyyy-MM-dd'T'HH:mm:ssXX");
+		PATTERNS.put(Pattern.compile("^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}[-+][0-9]{4}$"), "yyyy-MM-dd'T'HH:mmXX");
+		PATTERNS.put(Pattern.compile("^[0-9]{4}-[0-9]{2}-[0-9]{2}[-+][0-9]{4}$"), "yyyy-MM-ddXX");
+		
+		PATTERNS.put(Pattern.compile("^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\\.[0-9]+[-+][0-9]{2}$"), "yyyy-MM-dd'T'HH:mm:ss.SSSX");
+		PATTERNS.put(Pattern.compile("^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}[-+][0-9]{2}$"), "yyyy-MM-dd'T'HH:mm:ssX");
+		PATTERNS.put(Pattern.compile("^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}[-+][0-9]{2}$"), "yyyy-MM-dd'T'HH:mmX");
+		PATTERNS.put(Pattern.compile("^[0-9]{4}-[0-9]{2}-[0-9]{2}[-+][0-9]{2}$"), "yyyy-MM-ddX");
+		
+		PATTERNS.put(Pattern.compile("^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\\.[0-9]+[-+][0-9]{4}$"), "yyyy-MM-dd'T'HH:mm:ss.SSSZ");
+		PATTERNS.put(Pattern.compile("^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}[-+][0-9]{4}$"), "yyyy-MM-dd'T'HH:mm:ssZ");
+		PATTERNS.put(Pattern.compile("^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}[-+][0-9]{4}$"), "yyyy-MM-dd'T'HH:mmZ");
+		PATTERNS.put(Pattern.compile("^[0-9]{4}-[0-9]{2}-[0-9]{2}[-+][0-9]{4}$"), "yyyy-MM-ddZ");
+		
+		PATTERNS.put(Pattern.compile("^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\\.[0-9]+$"), "yyyy-MM-dd'T'HH:mm:ss.SSS");
+		PATTERNS.put(Pattern.compile("^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}$"), "yyyy-MM-dd'T'HH:mm:ss");
+		PATTERNS.put(Pattern.compile("^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}$"), "yyyy-MM-dd'T'HH:mm");
+		PATTERNS.put(Pattern.compile("^[0-9]{4}-[0-9]{2}-[0-9]{2}$"), "yyyy-MM-dd");
+		
+		PATTERNS.put(Pattern.compile("^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\\.[0-9]+ .*"), "yyyy-MM-dd'T'HH:mm:ss.SSS z");
+		PATTERNS.put(Pattern.compile("^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2} .*"), "yyyy-MM-dd'T'HH:mm:ss z");
+		PATTERNS.put(Pattern.compile("^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2} .*"), "yyyy-MM-dd'T'HH:mm z");
+	}
+}
+

--- a/core/src/test/java/org/dozer/converters/XMLGregorianCalendarConverterTest.java
+++ b/core/src/test/java/org/dozer/converters/XMLGregorianCalendarConverterTest.java
@@ -29,6 +29,8 @@ import org.junit.Test;
 
 public class XMLGregorianCalendarConverterTest extends AbstractDozerTest{
   private XMLGregorianCalendarConverter converter;
+  private XMLGregorianCalendarConverter converterISO8601;
+  private XMLGregorianCalendarConverter converterISO8601Z;
   private static final int YEAR = 1983;
   private static final int MONTH = 8;
   private static final int DAY = 4;
@@ -36,6 +38,8 @@ public class XMLGregorianCalendarConverterTest extends AbstractDozerTest{
   @Before
   public void setUp() throws Exception {
     converter = new XMLGregorianCalendarConverter(new SimpleDateFormat("dd.MM.yyyy"));
+    converterISO8601 = new XMLGregorianCalendarConverter(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX"));
+    converterISO8601Z = new XMLGregorianCalendarConverter(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ"));
   }
 
   @Test
@@ -94,5 +98,32 @@ public class XMLGregorianCalendarConverterTest extends AbstractDozerTest{
     assertNull(result);
   }
 
+  /**
+   * Test conversion of ISO8601 date with colon in time zone field.
+   * @throws Exception ISO 8601 date cannot be converted.
+   */
+  @Test
+  public void testConvert_ISO8601() throws Exception {
+    Object result = converterISO8601.convert(XMLGregorianCalendar.class, "1983-07-04T12:08:56.235-07:00");
+    XMLGregorianCalendar xmlCalendar = (XMLGregorianCalendar) result;
+
+    assertEquals(YEAR, xmlCalendar.getYear());
+    assertEquals(MONTH - 1, xmlCalendar.getMonth());
+    assertEquals(DAY, xmlCalendar.getDay());
+  }
+
+  /**
+   * Test conversion of ISO8601 date without colon in time zone field.
+   * @throws Exception ISO 8601 date cannot be converted.
+   */
+  @Test
+  public void testConvert_ISO8601Z() throws Exception {
+    Object result = converterISO8601Z.convert(XMLGregorianCalendar.class, "1983-07-04T12:08:56.235-0700");
+    XMLGregorianCalendar xmlCalendar = (XMLGregorianCalendar) result;
+
+    assertEquals(YEAR, xmlCalendar.getYear());
+    assertEquals(MONTH - 1, xmlCalendar.getMonth());
+    assertEquals(DAY, xmlCalendar.getDay());
+  }
 
 }

--- a/core/src/test/java/org/dozer/converters/custom/XmlDateConverterTest.java
+++ b/core/src/test/java/org/dozer/converters/custom/XmlDateConverterTest.java
@@ -1,0 +1,281 @@
+/**
+ * Copyright 2005-2013 Dozer Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dozer.converters.custom;
+
+import java.math.BigDecimal;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.TimeZone;
+
+import javax.xml.datatype.XMLGregorianCalendar;
+
+import org.dozer.AbstractDozerTest;
+import org.junit.Before;
+import org.junit.Test;
+
+public class XmlDateConverterTest extends AbstractDozerTest
+{
+	private static final String DATE_XML = "2015-02-22T01:59:28.766+00:00";
+	private static final long DATE_MS = 1424570368766L;
+	private static final int DATE_YEAR = 2015;
+	private static final int DATE_MONTH = 2;
+	private static final int DATE_DAY = 22;
+	private static final int DATE_HOUR = 1;
+	private static final int DATE_MINUTE = 59;
+	private static final int DATE_SECOND = 28;
+	private static final int DATE_FRACTION = 766;
+	private static final TimeZone DATE_TZ = TimeZone.getTimeZone("UTC");
+	  
+	private XmlDateConverter converter;
+
+	@Before
+	public void setUp() throws Exception
+	{
+		converter = new XmlDateConverter();
+	}
+
+	@Test
+	public void testXmlDateConverterDefaults() throws Exception 
+	{
+		assertEquals(XmlDateConverter.ISO8601, converter.getParameter());
+		assertNotNull(converter.getConverter());
+		assertNull(converter.convertFrom(null));
+		assertNull(converter.convertTo(null));
+	}
+	
+	@Test
+	public void testConvertFrom() throws Exception 
+	{
+		XMLGregorianCalendar xgcNow = XmlDateConverter.now();
+		String xmlNow = converter.convertFrom(xgcNow);
+		assertEquals(xgcNow.toXMLFormat(), xmlNow);
+	}
+	
+	@Test
+	public void testXMLConvertTo() throws Exception 
+	{
+		XMLGregorianCalendar xgc = converter.convertTo(DATE_XML);
+		assertMillis(DATE_MS, xgc);
+		assertYear(DATE_YEAR, xgc);
+		assertMonth(DATE_MONTH, xgc);
+		assertDay(DATE_DAY, xgc);
+		assertHour(DATE_HOUR, xgc);
+		assertMinute(DATE_MINUTE, xgc);
+		assertSecond(DATE_SECOND, xgc);
+		assertFraction(DATE_FRACTION, xgc);
+	}
+
+	@Test
+	public void testUtilDateConvertTo() throws Exception 
+	{
+		assertMillis(DATE_MS, converter.convertTo(new java.util.Date(DATE_MS)));
+	}
+
+	@Test
+	public void testSqlDateConvertTo() throws Exception 
+	{
+		assertMillis(DATE_MS, converter.convertTo(new java.sql.Date(DATE_MS)));
+	}
+
+	@Test
+	public void testCalendarConvertTo() throws Exception 
+	{
+		Calendar cal = Calendar.getInstance();
+		cal.setTimeInMillis(DATE_MS);
+		assertMillis(DATE_MS, converter.convertTo(cal));
+	}
+
+	@Test
+	public void testXGCConvertTo() throws Exception 
+	{
+		XMLGregorianCalendar xgcNow = XmlDateConverter.now();
+		assertMillis(xgcNow, converter.convertTo(xgcNow));
+	}
+
+	@Test
+	public void testMillisConvertTo() throws Exception 
+	{
+		assertMillis(DATE_MS, converter.convertTo(DATE_MS));
+	}
+
+	@Test
+	public void testPattern() throws Exception 
+	{
+		// 'T' delimited
+		assertEquals("yyyy-MM-dd'T'HH:mm:ss.SSSXXX", XmlDateConverter.pattern("2015-02-22T01:59:28.766+00:00"));
+		assertEquals("yyyy-MM-dd'T'HH:mm:ssXXX", XmlDateConverter.pattern("2015-02-22T01:59:28+00:00"));
+		assertEquals("yyyy-MM-dd'T'HH:mmXXX", XmlDateConverter.pattern("2015-02-22T01:59+00:00"));
+		assertEquals("yyyy-MM-ddXXX", XmlDateConverter.pattern("2015-02-22+00:00"));
+		assertEquals("yyyy-MM-dd'T'HH:mm:ss.SSSXX", XmlDateConverter.pattern("2015-02-22T01:59:28.766+0000"));
+		assertEquals("yyyy-MM-dd'T'HH:mm:ssXX", XmlDateConverter.pattern("2015-02-22T01:59:28+0000"));
+		assertEquals("yyyy-MM-dd'T'HH:mmXX", XmlDateConverter.pattern("2015-02-22T01:59+0000"));
+		assertEquals("yyyy-MM-ddXX", XmlDateConverter.pattern("2015-02-22+0000"));
+		assertEquals("yyyy-MM-dd'T'HH:mm:ss.SSSX", XmlDateConverter.pattern("2015-02-22T01:59:28.766+00"));
+		assertEquals("yyyy-MM-dd'T'HH:mm:ssX", XmlDateConverter.pattern("2015-02-22T01:59:28+00"));
+		assertEquals("yyyy-MM-dd'T'HH:mmX", XmlDateConverter.pattern("2015-02-22T01:59+00"));
+		assertEquals("yyyy-MM-ddX", XmlDateConverter.pattern("2015-02-22+00"));
+		assertEquals("yyyy-MM-dd'T'HH:mm:ss.SSSXXX", XmlDateConverter.pattern("2015-02-22T01:59:28.766Z"));
+		assertEquals("yyyy-MM-dd'T'HH:mm:ssXXX", XmlDateConverter.pattern("2015-02-22T01:59:28Z"));
+		assertEquals("yyyy-MM-dd'T'HH:mmXXX", XmlDateConverter.pattern("2015-02-22T01:59Z"));
+		assertEquals("yyyy-MM-dd'T'HH:mm:ss.SSS z", XmlDateConverter.pattern("2015-02-22T01:59:28.766 GMT"));
+		assertEquals("yyyy-MM-dd'T'HH:mm:ss z", XmlDateConverter.pattern("2015-02-22T01:59:28 GMT"));
+		assertEquals("yyyy-MM-dd'T'HH:mm z", XmlDateConverter.pattern("2015-02-22T01:59 GMT"));
+		assertEquals("yyyy-MM-dd'T'HH:mm:ss.SSS", XmlDateConverter.pattern("2015-02-22T01:59:28.766"));
+		assertEquals("yyyy-MM-dd'T'HH:mm:ss", XmlDateConverter.pattern("2015-02-22T01:59:28"));
+		assertEquals("yyyy-MM-dd'T'HH:mm", XmlDateConverter.pattern("2015-02-22T01:59"));
+
+		// ' ' delimited maps to 'T' patterns
+		assertEquals("yyyy-MM-dd'T'HH:mm:ss.SSSXXX", XmlDateConverter.pattern("2015-02-22 01:59:28.766+00:00"));
+		assertEquals("yyyy-MM-dd'T'HH:mm:ssXXX", XmlDateConverter.pattern("2015-02-22 01:59:28+00:00"));
+		assertEquals("yyyy-MM-dd'T'HH:mmXXX", XmlDateConverter.pattern("2015-02-22 01:59+00:00"));
+		assertEquals("yyyy-MM-dd'T'HH:mm:ss.SSSXX", XmlDateConverter.pattern("2015-02-22 01:59:28.766+0000"));
+		assertEquals("yyyy-MM-dd'T'HH:mm:ssXX", XmlDateConverter.pattern("2015-02-22 01:59:28+0000"));
+		assertEquals("yyyy-MM-dd'T'HH:mmXX", XmlDateConverter.pattern("2015-02-22 01:59+0000"));
+		assertEquals("yyyy-MM-dd'T'HH:mm:ss.SSSX", XmlDateConverter.pattern("2015-02-22 01:59:28.766+00"));
+		assertEquals("yyyy-MM-dd'T'HH:mm:ssX", XmlDateConverter.pattern("2015-02-22 01:59:28+00"));
+		assertEquals("yyyy-MM-dd'T'HH:mmX", XmlDateConverter.pattern("2015-02-22 01:59+00"));
+		assertEquals("yyyy-MM-dd'T'HH:mm:ss.SSSXXX", XmlDateConverter.pattern("2015-02-22 01:59:28.766Z"));
+		assertEquals("yyyy-MM-dd'T'HH:mm:ssXXX", XmlDateConverter.pattern("2015-02-22 01:59:28Z"));
+		assertEquals("yyyy-MM-dd'T'HH:mmXXX", XmlDateConverter.pattern("2015-02-22 01:59Z"));
+		assertEquals("yyyy-MM-dd'T'HH:mm:ss.SSS z", XmlDateConverter.pattern("2015-02-22 01:59:28.766 GMT"));
+		assertEquals("yyyy-MM-dd'T'HH:mm:ss z", XmlDateConverter.pattern("2015-02-22 01:59:28 GMT"));
+		assertEquals("yyyy-MM-dd'T'HH:mm z", XmlDateConverter.pattern("2015-02-22 01:59 GMT"));
+		assertEquals("yyyy-MM-dd'T'HH:mm:ss.SSS", XmlDateConverter.pattern("2015-02-22 01:59:28.766"));
+		assertEquals("yyyy-MM-dd'T'HH:mm:ss", XmlDateConverter.pattern("2015-02-22 01:59:28"));
+		assertEquals("yyyy-MM-dd'T'HH:mm", XmlDateConverter.pattern("2015-02-22 01:59"));
+	}
+	
+	@Test
+	public void testPatternConvertTo() throws Exception 
+	{
+		assertMillis(DATE_MS       , converter.convertTo("2015-02-22T01:59:28.766+00:00"));
+		assertMillis(1424570368000L, converter.convertTo("2015-02-22T01:59:28+00:00"));
+		assertMillis(1424570340000L, converter.convertTo("2015-02-22T01:59+00:00"));
+		assertMillis(1424563200000L, converter.convertTo("2015-02-22+00:00"));
+
+		assertMillis(DATE_MS       , converter.convertTo("2015-02-22T01:59:28.766+0000"));
+		assertMillis(1424570368000L, converter.convertTo("2015-02-22T01:59:28+0000"));
+		assertMillis(1424570340000L, converter.convertTo("2015-02-22T01:59+0000"));
+		assertMillis(1424563200000L, converter.convertTo("2015-02-22+0000"));
+
+		assertMillis(DATE_MS       , converter.convertTo("2015-02-22T01:59:28.766+00"));
+		assertMillis(1424570368000L, converter.convertTo("2015-02-22T01:59:28+00"));
+		assertMillis(1424570340000L, converter.convertTo("2015-02-22T01:59+00"));
+		assertMillis(1424563200000L, converter.convertTo("2015-02-22+00"));
+
+		assertMillis(DATE_MS       , converter.convertTo("2015-02-22T01:59:28.766Z"));
+		assertMillis(1424570368000L, converter.convertTo("2015-02-22T01:59:28Z"));
+		assertMillis(1424570340000L, converter.convertTo("2015-02-22T01:59Z"));
+
+		assertMillis(DATE_MS       , converter.convertTo("2015-02-22T01:59:28.766 GMT"));
+		assertMillis(1424570368000L, converter.convertTo("2015-02-22T01:59:28 GMT"));
+		assertMillis(1424570340000L, converter.convertTo("2015-02-22T01:59 GMT"));
+		
+		assertMillis(DATE_MS       , converter.convertTo("2015-02-22 01:59:28.766+00:00"));
+		assertMillis(1424570368000L, converter.convertTo("2015-02-22 01:59:28+00:00"));
+		assertMillis(1424570340000L, converter.convertTo("2015-02-22 01:59+00:00"));
+
+		assertMillis(DATE_MS       , converter.convertTo("2015-02-22 01:59:28.766+0000"));
+		assertMillis(1424570368000L, converter.convertTo("2015-02-22 01:59:28+0000"));
+		assertMillis(1424570340000L, converter.convertTo("2015-02-22 01:59+0000"));
+
+		assertMillis(DATE_MS       , converter.convertTo("2015-02-22 01:59:28.766+00"));
+		assertMillis(1424570368000L, converter.convertTo("2015-02-22 01:59:28+00"));
+		assertMillis(1424570340000L, converter.convertTo("2015-02-22 01:59+00"));
+
+		assertMillis(DATE_MS       , converter.convertTo("2015-02-22 01:59:28.766Z"));
+		assertMillis(1424570368000L, converter.convertTo("2015-02-22 01:59:28Z"));
+		assertMillis(1424570340000L, converter.convertTo("2015-02-22 01:59Z"));
+	
+		assertMillis(DATE_MS       , converter.convertTo("2015-02-22 01:59:28.766 GMT"));
+		assertMillis(1424570368000L, converter.convertTo("2015-02-22 01:59:28 GMT"));
+		assertMillis(1424570340000L, converter.convertTo("2015-02-22 01:59 GMT"));
+		
+		// Calculate time zone offset in milliseconds. 
+		Calendar zulu  = converter.convertTo("2015-02-22T01:59:28.766Z").toGregorianCalendar();
+		Calendar local = converter.convertTo("2015-02-22T01:59:28.766").toGregorianCalendar();
+		long TZMS = local.getTimeInMillis() - zulu.getTimeInMillis();
+
+		assertMillis(DATE_MS+TZMS       , converter.convertTo("2015-02-22T01:59:28.766"));
+		assertMillis(1424570368000L+TZMS, converter.convertTo("2015-02-22T01:59:28"));
+		assertMillis(1424570340000L+TZMS, converter.convertTo("2015-02-22T01:59"));
+		             
+		assertMillis(DATE_MS+TZMS       , converter.convertTo("2015-02-22 01:59:28.766"));
+		assertMillis(1424570368000L+TZMS, converter.convertTo("2015-02-22 01:59:28"));
+		assertMillis(1424570340000L+TZMS, converter.convertTo("2015-02-22 01:59"));
+		assertMillis(1424563200000L+TZMS, converter.convertTo("2015-02-22"));
+
+		Calendar edt = converter.convertTo("2015-02-22T01:59:28.766 EDT").toGregorianCalendar();
+		TZMS = edt.getTimeInMillis() - zulu.getTimeInMillis();
+
+		assertMillis(DATE_MS+TZMS       , converter.convertTo("2015-02-22T01:59:28.766 EDT"));
+		assertMillis(1424570368000L+TZMS, converter.convertTo("2015-02-22T01:59:28 EDT"));
+		assertMillis(1424570340000L+TZMS, converter.convertTo("2015-02-22T01:59 EDT"));
+		
+		// Pacific Daylight Time
+		Calendar pdt = converter.convertTo("2015-02-22T01:59:28.766 Pacific Daylight Time").toGregorianCalendar();
+		TZMS = pdt.getTimeInMillis() - zulu.getTimeInMillis();
+
+		assertMillis(DATE_MS+TZMS       , converter.convertTo("2015-02-22T01:59:28.766 Pacific Daylight Time"));
+		assertMillis(1424570368000L+TZMS, converter.convertTo("2015-02-22T01:59:28 Pacific Daylight Time"));
+		assertMillis(1424570340000L+TZMS, converter.convertTo("2015-02-22T01:59 Pacific Daylight Time"));
+	}
+	
+	private void assertMillis(XMLGregorianCalendar xgc1, XMLGregorianCalendar xgc2)
+	{
+		assertMillis(xgc1.toGregorianCalendar().getTimeInMillis(), xgc2);
+	}
+	
+	private void assertMillis(long millis, XMLGregorianCalendar xgc)
+	{
+		assertEquals(millis, xgc.toGregorianCalendar().getTimeInMillis());
+	}
+	
+	private void assertYear(int year, XMLGregorianCalendar xgc)
+	{
+		assertEquals(year, xgc.getYear());
+	}
+
+	private void assertMonth(int month, XMLGregorianCalendar xgc)
+	{
+		assertEquals(month, xgc.getMonth());
+	}
+
+	private void assertDay(int day, XMLGregorianCalendar xgc)
+	{
+		assertEquals(day, xgc.getDay() + 1);
+	}
+
+	private void assertHour(int hour, XMLGregorianCalendar xgc)
+	{
+		assertEquals(60 * hour, (60 * xgc.getHour() - xgc.getTimezone()) % 1440);
+	}
+
+	private void assertMinute(int minute, XMLGregorianCalendar xgc)
+	{
+		assertEquals(minute, xgc.getMinute());
+	}
+
+	private void assertSecond(int second, XMLGregorianCalendar xgc)
+	{
+		assertEquals(second, xgc.getSecond());
+	}
+
+	private void assertFraction(int fraction, XMLGregorianCalendar xgc)
+	{
+		assertEquals(fraction, xgc.getFractionalSecond().movePointRight(3).intValue());
+	}
+}


### PR DESCRIPTION
XmlDateConverter is a new custom converter used as a field mapping option to convert literal date-time strings in ISO8601 format to XMLGregorianCalendar objects. A typicall use case occurs when unmarshalling JSON into a Map of field names and object values then using Dozer to populate the JAXB generated classes. XmlDateConverter extends DozerConverter and wraps the existing XMLGregorianCalendarConverter so it can be used as a FieldMappingOption. This pull request includes unit and functional tests and updates the JAXB plugin in the POM to generate setters for XJC genetated 'List' properties. By generating List mutators, Dozer is able to copy Map lists into JAXB collections.