### PR TITLE
Implemented CustomFieldValidator to inject a point of prevention before a source field value is fetched during mapping

### DIFF
--- a/core/src/main/java/org/dozer/CustomFieldMapperAndValidator.java
+++ b/core/src/main/java/org/dozer/CustomFieldMapperAndValidator.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2005-2017 Dozer Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.dozer;
 
 /**

--- a/core/src/main/java/org/dozer/CustomFieldMapperAndValidator.java
+++ b/core/src/main/java/org/dozer/CustomFieldMapperAndValidator.java
@@ -1,0 +1,9 @@
+package org.dozer;
+
+/**
+ * Public custom field validator and mapper interface.
+ * Implement this interface on your custom field mapper if you want to implement both CustomFieldMapper & CustomFieldValidator functions
+ *
+ * @author Gilbert Grant
+ */
+public interface CustomFieldMapperAndValidator extends CustomFieldMapper, CustomFieldValidator {}

--- a/core/src/main/java/org/dozer/CustomFieldMapperAndValidator.java
+++ b/core/src/main/java/org/dozer/CustomFieldMapperAndValidator.java
@@ -2,7 +2,7 @@ package org.dozer;
 
 /**
  * Public custom field validator and mapper interface.
- * Implement this interface on your custom field mapper if you want to implement both CustomFieldMapper & CustomFieldValidator functions
+ * Implement this interface on your custom field mapper if you want to implement both CustomFieldMapper and CustomFieldValidator functions
  *
  * @author Gilbert Grant
  */

--- a/core/src/main/java/org/dozer/CustomFieldValidator.java
+++ b/core/src/main/java/org/dozer/CustomFieldValidator.java
@@ -16,5 +16,5 @@ import org.dozer.fieldmap.FieldMap;
  * @author Gilbert Grant
  */
 public interface CustomFieldValidator {
-	boolean canMapField(Object source, Object destination, ClassMap classMap, FieldMap fieldMapping);
+    boolean canMapField(Object source, Object destination, ClassMap classMap, FieldMap fieldMapping);
 }

--- a/core/src/main/java/org/dozer/CustomFieldValidator.java
+++ b/core/src/main/java/org/dozer/CustomFieldValidator.java
@@ -1,0 +1,20 @@
+package org.dozer;
+
+import org.dozer.classmap.ClassMap;
+import org.dozer.fieldmap.FieldMap;
+
+/**
+ * Public custom field validator interface. A custom field validator is usually in conjunction with a CustomFieldMapper
+ * when implementing the CustomFieldMapperAndValidator interface.
+ * Use this when you want logic to prevent source field values being fetched
+ * e.g. when checking lazy loaded relationships in an ORM
+ *
+ * <p>
+ * If a custom field validator is specified, Dozer will invoke this class when performing all field mappings. If false is
+ * returned from the call the source field value will never be fetched, and subsequently the field will never be mapped.
+ *
+ * @author Gilbert Grant
+ */
+public interface CustomFieldValidator {
+	boolean canMapField(Object source, Object destination, ClassMap classMap, FieldMap fieldMapping);
+}

--- a/core/src/main/java/org/dozer/CustomFieldValidator.java
+++ b/core/src/main/java/org/dozer/CustomFieldValidator.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2005-2017 Dozer Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.dozer;
 
 import org.dozer.classmap.ClassMap;

--- a/core/src/main/java/org/dozer/MappingProcessor.java
+++ b/core/src/main/java/org/dozer/MappingProcessor.java
@@ -337,30 +337,30 @@ public class MappingProcessor implements Mapper {
       // field was not actually mapped by the custom field mapper), proceed as
       // normal(use Dozer to map the field)
 
-	    boolean canMapField = true;
-	    if (customFieldMapper != null && customFieldMapper instanceof CustomFieldMapperAndValidator) {
-		    canMapField = ((CustomFieldMapperAndValidator)customFieldMapper).canMapField(srcObj, destObj, fieldMapping.getClassMap(), fieldMapping);
-	    }
+      boolean canMapField = true;
+      if (customFieldMapper != null && customFieldMapper instanceof CustomFieldMapperAndValidator) {
+        canMapField = ((CustomFieldMapperAndValidator)customFieldMapper).canMapField(srcObj, destObj, fieldMapping.getClassMap(), fieldMapping);
+      }
 
-	    if (canMapField) {
-		    boolean fieldMapped = false;
+      if (canMapField) {
+        boolean fieldMapped = false;
 
-		    srcFieldValue = fieldMapping.getSrcFieldValue(srcObj);
-		    if (customFieldMapper != null) {
-			    fieldMapped = customFieldMapper.mapField(srcObj, destObj, srcFieldValue, fieldMapping.getClassMap(), fieldMapping);
-		    }
+        srcFieldValue = fieldMapping.getSrcFieldValue(srcObj);
+        if (customFieldMapper != null) {
+          fieldMapped = customFieldMapper.mapField(srcObj, destObj, srcFieldValue, fieldMapping.getClassMap(), fieldMapping);
+        }
 
-		    if (!fieldMapped) {
-			    if (fieldMapping.getDestFieldType() != null && ITERATE.equals(fieldMapping.getDestFieldType())) {
-				    // special logic for iterate feature
-				    mapFromIterateMethodFieldMap(srcObj, destObj, srcFieldValue, fieldMapping);
-			    } else {
-				    // either deep field map or generic map. The is the most likely
-				    // scenario
-				    mapFromFieldMap(srcObj, destObj, srcFieldValue, fieldMapping);
-			    }
-		    }
-	    }
+        if (!fieldMapped) {
+          if (fieldMapping.getDestFieldType() != null && ITERATE.equals(fieldMapping.getDestFieldType())) {
+            // special logic for iterate feature
+            mapFromIterateMethodFieldMap(srcObj, destObj, srcFieldValue, fieldMapping);
+          } else {
+            // either deep field map or generic map. The is the most likely
+            // scenario
+            mapFromFieldMap(srcObj, destObj, srcFieldValue, fieldMapping);
+          }
+        }
+      }
 
       statsMgr.increment(StatisticType.FIELD_MAPPING_SUCCESS_COUNT);
 

--- a/core/src/main/java/org/dozer/MappingProcessor.java
+++ b/core/src/main/java/org/dozer/MappingProcessor.java
@@ -336,22 +336,31 @@ public class MappingProcessor implements Mapper {
       // custom field mapper returns false(indicating the
       // field was not actually mapped by the custom field mapper), proceed as
       // normal(use Dozer to map the field)
-      srcFieldValue = fieldMapping.getSrcFieldValue(srcObj);
-      boolean fieldMapped = false;
-      if (customFieldMapper != null) {
-        fieldMapped = customFieldMapper.mapField(srcObj, destObj, srcFieldValue, fieldMapping.getClassMap(), fieldMapping);
-      }
 
-      if (!fieldMapped) {
-        if (fieldMapping.getDestFieldType() != null && ITERATE.equals(fieldMapping.getDestFieldType())) {
-          // special logic for iterate feature
-          mapFromIterateMethodFieldMap(srcObj, destObj, srcFieldValue, fieldMapping);
-        } else {
-          // either deep field map or generic map. The is the most likely
-          // scenario
-          mapFromFieldMap(srcObj, destObj, srcFieldValue, fieldMapping);
-        }
-      }
+	    boolean canMapField = true;
+	    if (customFieldMapper != null && customFieldMapper instanceof CustomFieldMapperAndValidator) {
+		    canMapField = ((CustomFieldMapperAndValidator)customFieldMapper).canMapField(srcObj, destObj, fieldMapping.getClassMap(), fieldMapping);
+	    }
+
+	    if (canMapField) {
+		    boolean fieldMapped = false;
+
+		    srcFieldValue = fieldMapping.getSrcFieldValue(srcObj);
+		    if (customFieldMapper != null) {
+			    fieldMapped = customFieldMapper.mapField(srcObj, destObj, srcFieldValue, fieldMapping.getClassMap(), fieldMapping);
+		    }
+
+		    if (!fieldMapped) {
+			    if (fieldMapping.getDestFieldType() != null && ITERATE.equals(fieldMapping.getDestFieldType())) {
+				    // special logic for iterate feature
+				    mapFromIterateMethodFieldMap(srcObj, destObj, srcFieldValue, fieldMapping);
+			    } else {
+				    // either deep field map or generic map. The is the most likely
+				    // scenario
+				    mapFromFieldMap(srcObj, destObj, srcFieldValue, fieldMapping);
+			    }
+		    }
+	    }
 
       statsMgr.increment(StatisticType.FIELD_MAPPING_SUCCESS_COUNT);
 


### PR DESCRIPTION
A custom field validator is usually in conjunction with a
CustomFieldMapper when implementing the CustomFieldMapperAndValidator
interface.
Use this when you want logic to prevent source field values being
fetched.
e.g. when checking lazy loaded relationships in an ORM

If a custom field validator is specified, Dozer will invoke this class
when performing all field mappings. If false is returned from the call
the source field value will never be fetched, and subsequently the field
will never be mapped.
