### PR TITLE
Fix hint for primitive type

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,13 @@
+dist: trusty
 language: java
-
 jdk:
-  - openjdk6
-  - openjdk7
-  - oraclejdk7
-  - oraclejdk8
+- oraclejdk8
+install:
+- java -version && javac -version && mvn -version -B
+before_script:
+- mvn dependency:resolve-plugins -B
+script:
+- mvn clean install -B
+cache:
+  directories:
+  - $HOME/.m2

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright 2005-2013 Dozer Project
+Copyright 2005-2017 Dozer Project
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@
 [ ![Download](https://api.bintray.com/packages/buzdin/dozer-mapper/dozer/images/download.png) ](https://bintray.com/buzdin/dozer-mapper/dozer/_latestVersion)
 ================================
 
+Looking for HELP
+--------------------------------
+We are actively looking for people who want to help with the Dozer project!
+
 
 Why Map?
 --------------------------------

--- a/core/READMEFIRST.txt
+++ b/core/READMEFIRST.txt
@@ -1,5 +1,5 @@
 ====
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@
   <parent>
     <groupId>net.sf.dozer</groupId>
     <artifactId>dozer-parent</artifactId>
-    <version>5.5.1</version>
+    <version>6.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>dozer</artifactId>

--- a/core/src/main/java/org/dozer/BeanBuilder.java
+++ b/core/src/main/java/org/dozer/BeanBuilder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/BeanFactory.java
+++ b/core/src/main/java/org/dozer/BeanFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/BeanGeneralCreationStrategy.java
+++ b/core/src/main/java/org/dozer/BeanGeneralCreationStrategy.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/ConfigurableCustomConverter.java
+++ b/core/src/main/java/org/dozer/ConfigurableCustomConverter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/CustomConverter.java
+++ b/core/src/main/java/org/dozer/CustomConverter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/CustomFieldMapper.java
+++ b/core/src/main/java/org/dozer/CustomFieldMapper.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/DozerBeanMapper.java
+++ b/core/src/main/java/org/dozer/DozerBeanMapper.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/DozerBeanMapperSingletonWrapper.java
+++ b/core/src/main/java/org/dozer/DozerBeanMapperSingletonWrapper.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/DozerConverter.java
+++ b/core/src/main/java/org/dozer/DozerConverter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/DozerEventListener.java
+++ b/core/src/main/java/org/dozer/DozerEventListener.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/DozerInitializer.java
+++ b/core/src/main/java/org/dozer/DozerInitializer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/DozerModule.java
+++ b/core/src/main/java/org/dozer/DozerModule.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/MapIdField.java
+++ b/core/src/main/java/org/dozer/MapIdField.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2005-2017 Dozer Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.dozer;
 
 import java.util.HashMap;

--- a/core/src/main/java/org/dozer/MappedFieldsTracker.java
+++ b/core/src/main/java/org/dozer/MappedFieldsTracker.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/Mapper.java
+++ b/core/src/main/java/org/dozer/Mapper.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/MapperAware.java
+++ b/core/src/main/java/org/dozer/MapperAware.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/Mapping.java
+++ b/core/src/main/java/org/dozer/Mapping.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/MappingException.java
+++ b/core/src/main/java/org/dozer/MappingException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/MappingProcessor.java
+++ b/core/src/main/java/org/dozer/MappingProcessor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/MappingProcessor.java
+++ b/core/src/main/java/org/dozer/MappingProcessor.java
@@ -452,7 +452,12 @@ public class MappingProcessor implements Mapper {
     if (primitiveConverter.accepts(srcFieldClass) || primitiveConverter.accepts(destFieldType)) {
       // Primitive or Wrapper conversion
       if (fieldMap.getDestHintContainer() != null) {
-        destFieldType = fieldMap.getDestHintContainer().getHint();
+        Class<?> destHintType = fieldMap.getDestHintType(srcFieldValue.getClass());
+        // if the destType is null this means that there was more than one hint.
+        // we must have already set the destType then.
+        if (destHintType != null) {
+          destFieldType = destHintType;
+        }
       }
 
       //#1841448 - if trim-strings=true, then use a trimmed src string value when converting to dest value

--- a/core/src/main/java/org/dozer/builder/BeanBuilderCreationStrategy.java
+++ b/core/src/main/java/org/dozer/builder/BeanBuilderCreationStrategy.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/builder/BuilderUtil.java
+++ b/core/src/main/java/org/dozer/builder/BuilderUtil.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/builder/DestBeanBuilderCreator.java
+++ b/core/src/main/java/org/dozer/builder/DestBeanBuilderCreator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/cache/Cache.java
+++ b/core/src/main/java/org/dozer/cache/Cache.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/cache/CacheEntry.java
+++ b/core/src/main/java/org/dozer/cache/CacheEntry.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/cache/CacheKeyFactory.java
+++ b/core/src/main/java/org/dozer/cache/CacheKeyFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/cache/CacheManager.java
+++ b/core/src/main/java/org/dozer/cache/CacheManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/cache/DozerCache.java
+++ b/core/src/main/java/org/dozer/cache/DozerCache.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/cache/DozerCacheManager.java
+++ b/core/src/main/java/org/dozer/cache/DozerCacheManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/cache/DozerCacheType.java
+++ b/core/src/main/java/org/dozer/cache/DozerCacheType.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/classmap/AllowedExceptionContainer.java
+++ b/core/src/main/java/org/dozer/classmap/AllowedExceptionContainer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/classmap/ClassMap.java
+++ b/core/src/main/java/org/dozer/classmap/ClassMap.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/classmap/ClassMapBuilder.java
+++ b/core/src/main/java/org/dozer/classmap/ClassMapBuilder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2014 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/classmap/ClassMapKeyFactory.java
+++ b/core/src/main/java/org/dozer/classmap/ClassMapKeyFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/classmap/ClassMappings.java
+++ b/core/src/main/java/org/dozer/classmap/ClassMappings.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/classmap/Configuration.java
+++ b/core/src/main/java/org/dozer/classmap/Configuration.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/classmap/CopyByReference.java
+++ b/core/src/main/java/org/dozer/classmap/CopyByReference.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/classmap/CopyByReferenceContainer.java
+++ b/core/src/main/java/org/dozer/classmap/CopyByReferenceContainer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/classmap/DozerClass.java
+++ b/core/src/main/java/org/dozer/classmap/DozerClass.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/classmap/MappingDirection.java
+++ b/core/src/main/java/org/dozer/classmap/MappingDirection.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/classmap/MappingFileData.java
+++ b/core/src/main/java/org/dozer/classmap/MappingFileData.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/classmap/RelationshipType.java
+++ b/core/src/main/java/org/dozer/classmap/RelationshipType.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/classmap/generator/BeanMappingGenerator.java
+++ b/core/src/main/java/org/dozer/classmap/generator/BeanMappingGenerator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/classmap/generator/ClassLevelFieldMappingGenerator.java
+++ b/core/src/main/java/org/dozer/classmap/generator/ClassLevelFieldMappingGenerator.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2005-2017 Dozer Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.dozer.classmap.generator;
 
 import org.dozer.classmap.ClassMap;

--- a/core/src/main/java/org/dozer/classmap/generator/GeneratorUtils.java
+++ b/core/src/main/java/org/dozer/classmap/generator/GeneratorUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/classmap/generator/JavaBeanFieldsDetector.java
+++ b/core/src/main/java/org/dozer/classmap/generator/JavaBeanFieldsDetector.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2014 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/classmap/generator/MappingType.java
+++ b/core/src/main/java/org/dozer/classmap/generator/MappingType.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2005-2017 Dozer Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.dozer.classmap.generator;
 
 /**

--- a/core/src/main/java/org/dozer/config/BeanContainer.java
+++ b/core/src/main/java/org/dozer/config/BeanContainer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/config/GlobalSettings.java
+++ b/core/src/main/java/org/dozer/config/GlobalSettings.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/config/PropertyConstants.java
+++ b/core/src/main/java/org/dozer/config/PropertyConstants.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/converters/ByteConverter.java
+++ b/core/src/main/java/org/dozer/converters/ByteConverter.java
@@ -1,5 +1,5 @@
-/*
- * Copyright 2005-2010 the original author or authors.
+/**
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/converters/CalendarConverter.java
+++ b/core/src/main/java/org/dozer/converters/CalendarConverter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/converters/ConversionException.java
+++ b/core/src/main/java/org/dozer/converters/ConversionException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/converters/CustomConverterContainer.java
+++ b/core/src/main/java/org/dozer/converters/CustomConverterContainer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/converters/CustomConverterDescription.java
+++ b/core/src/main/java/org/dozer/converters/CustomConverterDescription.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/converters/DateConverter.java
+++ b/core/src/main/java/org/dozer/converters/DateConverter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/converters/DateFormatContainer.java
+++ b/core/src/main/java/org/dozer/converters/DateFormatContainer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/converters/EnumConverter.java
+++ b/core/src/main/java/org/dozer/converters/EnumConverter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/converters/IntegerConverter.java
+++ b/core/src/main/java/org/dozer/converters/IntegerConverter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/converters/JAXBElementConverter.java
+++ b/core/src/main/java/org/dozer/converters/JAXBElementConverter.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2005-2017 Dozer Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.dozer.converters;
 
 import java.lang.reflect.Method;

--- a/core/src/main/java/org/dozer/converters/LongConverter.java
+++ b/core/src/main/java/org/dozer/converters/LongConverter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/converters/PrimitiveOrWrapperConverter.java
+++ b/core/src/main/java/org/dozer/converters/PrimitiveOrWrapperConverter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/converters/ShortConverter.java
+++ b/core/src/main/java/org/dozer/converters/ShortConverter.java
@@ -1,5 +1,5 @@
-/*
- * Copyright 2005-2010 the original author or authors.
+/**
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/converters/StringConstructorConverter.java
+++ b/core/src/main/java/org/dozer/converters/StringConstructorConverter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/converters/StringConverter.java
+++ b/core/src/main/java/org/dozer/converters/StringConverter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/converters/XMLGregorianCalendarConverter.java
+++ b/core/src/main/java/org/dozer/converters/XMLGregorianCalendarConverter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/event/DozerEvent.java
+++ b/core/src/main/java/org/dozer/event/DozerEvent.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/event/DozerEventManager.java
+++ b/core/src/main/java/org/dozer/event/DozerEventManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/event/DozerEventType.java
+++ b/core/src/main/java/org/dozer/event/DozerEventType.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/event/EventManager.java
+++ b/core/src/main/java/org/dozer/event/EventManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/factory/BeanCreationDirective.java
+++ b/core/src/main/java/org/dozer/factory/BeanCreationDirective.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/factory/BeanCreationStrategy.java
+++ b/core/src/main/java/org/dozer/factory/BeanCreationStrategy.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/factory/ConstructionStrategies.java
+++ b/core/src/main/java/org/dozer/factory/ConstructionStrategies.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/factory/DestBeanCreator.java
+++ b/core/src/main/java/org/dozer/factory/DestBeanCreator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/factory/JAXBBeanFactory.java
+++ b/core/src/main/java/org/dozer/factory/JAXBBeanFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/factory/XMLBeanFactory.java
+++ b/core/src/main/java/org/dozer/factory/XMLBeanFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/fieldmap/CustomGetSetMethodFieldMap.java
+++ b/core/src/main/java/org/dozer/fieldmap/CustomGetSetMethodFieldMap.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/fieldmap/DozerField.java
+++ b/core/src/main/java/org/dozer/fieldmap/DozerField.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/fieldmap/ExcludeFieldMap.java
+++ b/core/src/main/java/org/dozer/fieldmap/ExcludeFieldMap.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/fieldmap/FieldMap.java
+++ b/core/src/main/java/org/dozer/fieldmap/FieldMap.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/fieldmap/GenericFieldMap.java
+++ b/core/src/main/java/org/dozer/fieldmap/GenericFieldMap.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/fieldmap/HintContainer.java
+++ b/core/src/main/java/org/dozer/fieldmap/HintContainer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/fieldmap/MapFieldMap.java
+++ b/core/src/main/java/org/dozer/fieldmap/MapFieldMap.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/inject/BeanRegistry.java
+++ b/core/src/main/java/org/dozer/inject/BeanRegistry.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/inject/DozerBeanContainer.java
+++ b/core/src/main/java/org/dozer/inject/DozerBeanContainer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/inject/Inject.java
+++ b/core/src/main/java/org/dozer/inject/Inject.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/jmx/DozerAdminController.java
+++ b/core/src/main/java/org/dozer/jmx/DozerAdminController.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/jmx/DozerAdminControllerMBean.java
+++ b/core/src/main/java/org/dozer/jmx/DozerAdminControllerMBean.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/jmx/DozerStatisticsController.java
+++ b/core/src/main/java/org/dozer/jmx/DozerStatisticsController.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/jmx/DozerStatisticsControllerMBean.java
+++ b/core/src/main/java/org/dozer/jmx/DozerStatisticsControllerMBean.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/jmx/JMXPlatform.java
+++ b/core/src/main/java/org/dozer/jmx/JMXPlatform.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/jmx/JMXPlatformImpl.java
+++ b/core/src/main/java/org/dozer/jmx/JMXPlatformImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/loader/CustomMappingsLoader.java
+++ b/core/src/main/java/org/dozer/loader/CustomMappingsLoader.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/loader/DozerBuilder.java
+++ b/core/src/main/java/org/dozer/loader/DozerBuilder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/loader/LoadMappingsResult.java
+++ b/core/src/main/java/org/dozer/loader/LoadMappingsResult.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/loader/MappingsParser.java
+++ b/core/src/main/java/org/dozer/loader/MappingsParser.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/loader/MappingsSource.java
+++ b/core/src/main/java/org/dozer/loader/MappingsSource.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/loader/api/BeanMappingBuilder.java
+++ b/core/src/main/java/org/dozer/loader/api/BeanMappingBuilder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/loader/api/FieldDefinition.java
+++ b/core/src/main/java/org/dozer/loader/api/FieldDefinition.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/loader/api/FieldsMappingOption.java
+++ b/core/src/main/java/org/dozer/loader/api/FieldsMappingOption.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/loader/api/FieldsMappingOptions.java
+++ b/core/src/main/java/org/dozer/loader/api/FieldsMappingOptions.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/loader/api/TypeDefinition.java
+++ b/core/src/main/java/org/dozer/loader/api/TypeDefinition.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/loader/api/TypeMappingBuilder.java
+++ b/core/src/main/java/org/dozer/loader/api/TypeMappingBuilder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/loader/api/TypeMappingOption.java
+++ b/core/src/main/java/org/dozer/loader/api/TypeMappingOption.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/loader/api/TypeMappingOptions.java
+++ b/core/src/main/java/org/dozer/loader/api/TypeMappingOptions.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/loader/xml/DozerResolver.java
+++ b/core/src/main/java/org/dozer/loader/xml/DozerResolver.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/loader/xml/ELEngine.java
+++ b/core/src/main/java/org/dozer/loader/xml/ELEngine.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/loader/xml/ElementReader.java
+++ b/core/src/main/java/org/dozer/loader/xml/ElementReader.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/loader/xml/ExpressionElementReader.java
+++ b/core/src/main/java/org/dozer/loader/xml/ExpressionElementReader.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/loader/xml/MappingFileReader.java
+++ b/core/src/main/java/org/dozer/loader/xml/MappingFileReader.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/loader/xml/MappingStreamReader.java
+++ b/core/src/main/java/org/dozer/loader/xml/MappingStreamReader.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/loader/xml/SimpleElementReader.java
+++ b/core/src/main/java/org/dozer/loader/xml/SimpleElementReader.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/loader/xml/XMLParser.java
+++ b/core/src/main/java/org/dozer/loader/xml/XMLParser.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/loader/xml/XMLParserFactory.java
+++ b/core/src/main/java/org/dozer/loader/xml/XMLParserFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/metadata/ClassMappingMetadata.java
+++ b/core/src/main/java/org/dozer/metadata/ClassMappingMetadata.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/metadata/DozerClassMappingMetadata.java
+++ b/core/src/main/java/org/dozer/metadata/DozerClassMappingMetadata.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/metadata/DozerFieldMappingMetadata.java
+++ b/core/src/main/java/org/dozer/metadata/DozerFieldMappingMetadata.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/metadata/DozerMappingMetadata.java
+++ b/core/src/main/java/org/dozer/metadata/DozerMappingMetadata.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/metadata/FieldMappingMetadata.java
+++ b/core/src/main/java/org/dozer/metadata/FieldMappingMetadata.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/metadata/MappingMetadata.java
+++ b/core/src/main/java/org/dozer/metadata/MappingMetadata.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/metadata/MetadataLookupException.java
+++ b/core/src/main/java/org/dozer/metadata/MetadataLookupException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/osgi/Activator.java
+++ b/core/src/main/java/org/dozer/osgi/Activator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/osgi/OSGiClassLoader.java
+++ b/core/src/main/java/org/dozer/osgi/OSGiClassLoader.java
@@ -1,5 +1,5 @@
-/*
- * Copyright 2005-2013 the original author or authors.
+/**
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.dozer.osgi;
 
 import org.dozer.MappingException;

--- a/core/src/main/java/org/dozer/propertydescriptor/AbstractPropertyDescriptor.java
+++ b/core/src/main/java/org/dozer/propertydescriptor/AbstractPropertyDescriptor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/propertydescriptor/CustomGetSetPropertyDescriptor.java
+++ b/core/src/main/java/org/dozer/propertydescriptor/CustomGetSetPropertyDescriptor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/propertydescriptor/DeepHierarchyElement.java
+++ b/core/src/main/java/org/dozer/propertydescriptor/DeepHierarchyElement.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/propertydescriptor/DozerPropertyDescriptor.java
+++ b/core/src/main/java/org/dozer/propertydescriptor/DozerPropertyDescriptor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/propertydescriptor/FieldPropertyDescriptor.java
+++ b/core/src/main/java/org/dozer/propertydescriptor/FieldPropertyDescriptor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/propertydescriptor/GetterSetterPropertyDescriptor.java
+++ b/core/src/main/java/org/dozer/propertydescriptor/GetterSetterPropertyDescriptor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/propertydescriptor/JavaBeanPropertyDescriptor.java
+++ b/core/src/main/java/org/dozer/propertydescriptor/JavaBeanPropertyDescriptor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2014 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/propertydescriptor/MapPropertyDescriptor.java
+++ b/core/src/main/java/org/dozer/propertydescriptor/MapPropertyDescriptor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/propertydescriptor/PropertyDescriptorCreationStrategy.java
+++ b/core/src/main/java/org/dozer/propertydescriptor/PropertyDescriptorCreationStrategy.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/propertydescriptor/PropertyDescriptorFactory.java
+++ b/core/src/main/java/org/dozer/propertydescriptor/PropertyDescriptorFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/propertydescriptor/SelfPropertyDescriptor.java
+++ b/core/src/main/java/org/dozer/propertydescriptor/SelfPropertyDescriptor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/propertydescriptor/XmlBeanPropertyDescriptor.java
+++ b/core/src/main/java/org/dozer/propertydescriptor/XmlBeanPropertyDescriptor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/stats/GlobalStatistics.java
+++ b/core/src/main/java/org/dozer/stats/GlobalStatistics.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/stats/Statistic.java
+++ b/core/src/main/java/org/dozer/stats/Statistic.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/stats/StatisticEntry.java
+++ b/core/src/main/java/org/dozer/stats/StatisticEntry.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/stats/StatisticType.java
+++ b/core/src/main/java/org/dozer/stats/StatisticType.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/stats/StatisticsInterceptor.java
+++ b/core/src/main/java/org/dozer/stats/StatisticsInterceptor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/stats/StatisticsManager.java
+++ b/core/src/main/java/org/dozer/stats/StatisticsManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/stats/StatisticsManagerImpl.java
+++ b/core/src/main/java/org/dozer/stats/StatisticsManagerImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/util/BridgedMethodFinder.java
+++ b/core/src/main/java/org/dozer/util/BridgedMethodFinder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/util/CollectionUtils.java
+++ b/core/src/main/java/org/dozer/util/CollectionUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/util/DeepHierarchyUtils.java
+++ b/core/src/main/java/org/dozer/util/DeepHierarchyUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/util/DefaultClassLoader.java
+++ b/core/src/main/java/org/dozer/util/DefaultClassLoader.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/util/DefaultProxyResolver.java
+++ b/core/src/main/java/org/dozer/util/DefaultProxyResolver.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/util/DozerClassLoader.java
+++ b/core/src/main/java/org/dozer/util/DozerClassLoader.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/util/DozerConstants.java
+++ b/core/src/main/java/org/dozer/util/DozerConstants.java
@@ -69,5 +69,6 @@ public final class DozerConstants {
 
   public static final String JAVASSIST_PACKAGE = "org.javassist.tmp.";
   public static final String JAVASSIST_SYMBOL = "_$$_javassist_";
+  public static final String JAVASSIST_SYMBOL_2 = "_$$_jvst";
 
 }

--- a/core/src/main/java/org/dozer/util/DozerConstants.java
+++ b/core/src/main/java/org/dozer/util/DozerConstants.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/util/DozerProxyResolver.java
+++ b/core/src/main/java/org/dozer/util/DozerProxyResolver.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/util/HibernateProxyResolver.java
+++ b/core/src/main/java/org/dozer/util/HibernateProxyResolver.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/util/IteratorUtils.java
+++ b/core/src/main/java/org/dozer/util/IteratorUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/util/JavassistProxyResolver.java
+++ b/core/src/main/java/org/dozer/util/JavassistProxyResolver.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2005-2017 Dozer Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.dozer.util;
 
 import javassist.util.proxy.ProxyFactory;

--- a/core/src/main/java/org/dozer/util/LogMsgFactory.java
+++ b/core/src/main/java/org/dozer/util/LogMsgFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/util/MappingUtils.java
+++ b/core/src/main/java/org/dozer/util/MappingUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/util/MappingValidator.java
+++ b/core/src/main/java/org/dozer/util/MappingValidator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/util/NoProxyResolver.java
+++ b/core/src/main/java/org/dozer/util/NoProxyResolver.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/util/ReflectionUtils.java
+++ b/core/src/main/java/org/dozer/util/ReflectionUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2014 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/util/ResourceLoader.java
+++ b/core/src/main/java/org/dozer/util/ResourceLoader.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/util/TypeResolver.java
+++ b/core/src/main/java/org/dozer/util/TypeResolver.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/misc/docs/HowToRelease.txt
+++ b/core/src/misc/docs/HowToRelease.txt
@@ -1,5 +1,5 @@
 ====
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/misc/docs/HowToRunJMXTestEngine.txt
+++ b/core/src/misc/docs/HowToRunJMXTestEngine.txt
@@ -1,5 +1,5 @@
 ====
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/misc/eclipseFormattingProfile.xml
+++ b/core/src/misc/eclipseFormattingProfile.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/misc/jmx-testengine/JMXTestEngine.java
+++ b/core/src/misc/jmx-testengine/JMXTestEngine.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/misc/jmx-testengine/jmx_test_engine.properties
+++ b/core/src/misc/jmx-testengine/jmx_test_engine.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2005-2013 Dozer Project
+# Copyright 2005-2017 Dozer Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/core/src/site/misc/release_notes.rb
+++ b/core/src/site/misc/release_notes.rb
@@ -1,5 +1,5 @@
 #
-# Copyright 2005-2013 Dozer Project
+# Copyright 2005-2017 Dozer Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/core/src/site/pdf.xml
+++ b/core/src/site/pdf.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/site/resources/dtd/dozerbeanmapping.dtd
+++ b/core/src/site/resources/dtd/dozerbeanmapping.dtd
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/site/resources/eclipse-plugin/site.xml
+++ b/core/src/site/resources/eclipse-plugin/site.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/site/resources/schema/beanmapping.xsd
+++ b/core/src/site/resources/schema/beanmapping.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/site/site.xml
+++ b/core/src/site/site.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/site/xdoc/documentation/about.xml
+++ b/core/src/site/xdoc/documentation/about.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/site/xdoc/documentation/advancedConfiguration.xml
+++ b/core/src/site/xdoc/documentation/advancedConfiguration.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/site/xdoc/documentation/advancedproperty.xml
+++ b/core/src/site/xdoc/documentation/advancedproperty.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/site/xdoc/documentation/annotations.xml
+++ b/core/src/site/xdoc/documentation/annotations.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/site/xdoc/documentation/apimappings.xml
+++ b/core/src/site/xdoc/documentation/apimappings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/site/xdoc/documentation/articles.xml
+++ b/core/src/site/xdoc/documentation/articles.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/site/xdoc/documentation/baseattributes.xml
+++ b/core/src/site/xdoc/documentation/baseattributes.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/site/xdoc/documentation/collectionandarraymapping.xml
+++ b/core/src/site/xdoc/documentation/collectionandarraymapping.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/site/xdoc/documentation/configuration/configuration.xml
+++ b/core/src/site/xdoc/documentation/configuration/configuration.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/site/xdoc/documentation/configuration/logging.xml
+++ b/core/src/site/xdoc/documentation/configuration/logging.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/site/xdoc/documentation/configuration/statistics.xml
+++ b/core/src/site/xdoc/documentation/configuration/statistics.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/site/xdoc/documentation/contextmapping.xml
+++ b/core/src/site/xdoc/documentation/contextmapping.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/site/xdoc/documentation/copybyreference.xml
+++ b/core/src/site/xdoc/documentation/copybyreference.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/site/xdoc/documentation/customCreateMethod.xml
+++ b/core/src/site/xdoc/documentation/customCreateMethod.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/site/xdoc/documentation/custombeanfactories.xml
+++ b/core/src/site/xdoc/documentation/custombeanfactories.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/site/xdoc/documentation/customconverter.xml
+++ b/core/src/site/xdoc/documentation/customconverter.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/site/xdoc/documentation/custommethods.xml
+++ b/core/src/site/xdoc/documentation/custommethods.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/site/xdoc/documentation/deepmapping.xml
+++ b/core/src/site/xdoc/documentation/deepmapping.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/site/xdoc/documentation/eclipse-plugin/installation.xml
+++ b/core/src/site/xdoc/documentation/eclipse-plugin/installation.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/site/xdoc/documentation/eclipse-plugin/usage-editor.xml
+++ b/core/src/site/xdoc/documentation/eclipse-plugin/usage-editor.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/site/xdoc/documentation/eclipse-plugin/usage-xml.xml
+++ b/core/src/site/xdoc/documentation/eclipse-plugin/usage-xml.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/site/xdoc/documentation/eclipse-plugin/usage.xml
+++ b/core/src/site/xdoc/documentation/eclipse-plugin/usage.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/site/xdoc/documentation/enum.xml
+++ b/core/src/site/xdoc/documentation/enum.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/site/xdoc/documentation/events.xml
+++ b/core/src/site/xdoc/documentation/events.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/site/xdoc/documentation/exclude.xml
+++ b/core/src/site/xdoc/documentation/exclude.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/site/xdoc/documentation/expressionlanguage.xml
+++ b/core/src/site/xdoc/documentation/expressionlanguage.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/site/xdoc/documentation/faq.xml
+++ b/core/src/site/xdoc/documentation/faq.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/site/xdoc/documentation/gettingstarted.xml
+++ b/core/src/site/xdoc/documentation/gettingstarted.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/site/xdoc/documentation/globalConfiguration.xml
+++ b/core/src/site/xdoc/documentation/globalConfiguration.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/site/xdoc/documentation/indexmapping.xml
+++ b/core/src/site/xdoc/documentation/indexmapping.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/site/xdoc/documentation/jmxintegration.xml
+++ b/core/src/site/xdoc/documentation/jmxintegration.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/site/xdoc/documentation/mapbackedproperty.xml
+++ b/core/src/site/xdoc/documentation/mapbackedproperty.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/site/xdoc/documentation/mappingclasses.xml
+++ b/core/src/site/xdoc/documentation/mappingclasses.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/site/xdoc/documentation/mappings.xml
+++ b/core/src/site/xdoc/documentation/mappings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/site/xdoc/documentation/metadata.xml
+++ b/core/src/site/xdoc/documentation/metadata.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/site/xdoc/documentation/oneway.xml
+++ b/core/src/site/xdoc/documentation/oneway.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/site/xdoc/documentation/proxyhandling.xml
+++ b/core/src/site/xdoc/documentation/proxyhandling.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/site/xdoc/documentation/simpleproperty.xml
+++ b/core/src/site/xdoc/documentation/simpleproperty.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/site/xdoc/documentation/springintegration.xml
+++ b/core/src/site/xdoc/documentation/springintegration.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/site/xdoc/documentation/stringtodatemapping.xml
+++ b/core/src/site/xdoc/documentation/stringtodatemapping.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/site/xdoc/documentation/support.xml
+++ b/core/src/site/xdoc/documentation/support.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/site/xdoc/documentation/template.xml
+++ b/core/src/site/xdoc/documentation/template.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/site/xdoc/documentation/usage.xml
+++ b/core/src/site/xdoc/documentation/usage.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/site/xdoc/documentation/whymap.xml
+++ b/core/src/site/xdoc/documentation/whymap.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/site/xdoc/documentation/xmlbeans.xml
+++ b/core/src/site/xdoc/documentation/xmlbeans.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/site/xdoc/downloading.xml
+++ b/core/src/site/xdoc/downloading.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/site/xdoc/examples.xml
+++ b/core/src/site/xdoc/examples.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/site/xdoc/index.xml
+++ b/core/src/site/xdoc/index.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/site/xdoc/license.xml
+++ b/core/src/site/xdoc/license.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/site/xdoc/releasenotes.xml
+++ b/core/src/site/xdoc/releasenotes.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/AbstractDozerTest.java
+++ b/core/src/test/java/org/dozer/AbstractDozerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/DozerBeanMapperTest.java
+++ b/core/src/test/java/org/dozer/DozerBeanMapperTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/DozerConverterTest.java
+++ b/core/src/test/java/org/dozer/DozerConverterTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/DozerInitializerTest.java
+++ b/core/src/test/java/org/dozer/DozerInitializerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/MapIdFieldTest.java
+++ b/core/src/test/java/org/dozer/MapIdFieldTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/MappedFieldsTrackerTest.java
+++ b/core/src/test/java/org/dozer/MappedFieldsTrackerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/MappingProcessorArrayTest.java
+++ b/core/src/test/java/org/dozer/MappingProcessorArrayTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2005-2017 Dozer Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.dozer;
 
 import org.junit.Test;

--- a/core/src/test/java/org/dozer/MappingProcessorTest.java
+++ b/core/src/test/java/org/dozer/MappingProcessorTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/cache/CacheEntryTest.java
+++ b/core/src/test/java/org/dozer/cache/CacheEntryTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/cache/CacheKeyFactoryTest.java
+++ b/core/src/test/java/org/dozer/cache/CacheKeyFactoryTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/cache/DozerCacheManagerTest.java
+++ b/core/src/test/java/org/dozer/cache/DozerCacheManagerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/cache/DozerCacheTest.java
+++ b/core/src/test/java/org/dozer/cache/DozerCacheTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/classmap/ClassMapBuilderTest.java
+++ b/core/src/test/java/org/dozer/classmap/ClassMapBuilderTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/classmap/ClassMapKeyFactoryTest.java
+++ b/core/src/test/java/org/dozer/classmap/ClassMapKeyFactoryTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/classmap/ClassMapTest.java
+++ b/core/src/test/java/org/dozer/classmap/ClassMapTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/classmap/ClassMappingsTest.java
+++ b/core/src/test/java/org/dozer/classmap/ClassMappingsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/classmap/CopyByReferenceContainerTest.java
+++ b/core/src/test/java/org/dozer/classmap/CopyByReferenceContainerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/classmap/CopyByReferenceTest.java
+++ b/core/src/test/java/org/dozer/classmap/CopyByReferenceTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/classmap/MappingDirectionTest.java
+++ b/core/src/test/java/org/dozer/classmap/MappingDirectionTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/classmap/RelationshipTypeTest.java
+++ b/core/src/test/java/org/dozer/classmap/RelationshipTypeTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/classmap/generator/GeneratorUtilsTest.java
+++ b/core/src/test/java/org/dozer/classmap/generator/GeneratorUtilsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/config/GlobalSettingsTest.java
+++ b/core/src/test/java/org/dozer/config/GlobalSettingsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/converters/ConverterTest.java
+++ b/core/src/test/java/org/dozer/converters/ConverterTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/converters/CustomConverterContainerTest.java
+++ b/core/src/test/java/org/dozer/converters/CustomConverterContainerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/converters/DateConverterTest.java
+++ b/core/src/test/java/org/dozer/converters/DateConverterTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/converters/IntegerConverterTest.java
+++ b/core/src/test/java/org/dozer/converters/IntegerConverterTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/converters/JAXBElementConverterTest.java
+++ b/core/src/test/java/org/dozer/converters/JAXBElementConverterTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/converters/PrimitiveOrWrapperConverterTest.java
+++ b/core/src/test/java/org/dozer/converters/PrimitiveOrWrapperConverterTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/converters/StringConstructorConverterTest.java
+++ b/core/src/test/java/org/dozer/converters/StringConstructorConverterTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/converters/StringConverterTest.java
+++ b/core/src/test/java/org/dozer/converters/StringConverterTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/converters/XMLGregorianCalendarConverterTest.java
+++ b/core/src/test/java/org/dozer/converters/XMLGregorianCalendarConverterTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/event/DozerEventManagerTest.java
+++ b/core/src/test/java/org/dozer/event/DozerEventManagerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/event/DozerEventTest.java
+++ b/core/src/test/java/org/dozer/event/DozerEventTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/factory/ConstructionStrategiesTest.java
+++ b/core/src/test/java/org/dozer/factory/ConstructionStrategiesTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/factory/DestBeanCreatorTest.java
+++ b/core/src/test/java/org/dozer/factory/DestBeanCreatorTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/factory/JAXBBeanFactoryTest.java
+++ b/core/src/test/java/org/dozer/factory/JAXBBeanFactoryTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/fieldmap/FieldMapTest.java
+++ b/core/src/test/java/org/dozer/fieldmap/FieldMapTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/fieldmap/MapFieldMapTest.java
+++ b/core/src/test/java/org/dozer/fieldmap/MapFieldMapTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/functional_tests/AbstractFunctionalTest.java
+++ b/core/src/test/java/org/dozer/functional_tests/AbstractFunctionalTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/functional_tests/BiDirectionalMappingTest.java
+++ b/core/src/test/java/org/dozer/functional_tests/BiDirectionalMappingTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/functional_tests/CircularDependenciesTest.java
+++ b/core/src/test/java/org/dozer/functional_tests/CircularDependenciesTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/functional_tests/ClassLevelIsAccessibleTest.java
+++ b/core/src/test/java/org/dozer/functional_tests/ClassLevelIsAccessibleTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2005-2017 Dozer Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.dozer.functional_tests;
 
 import org.dozer.Mapping;

--- a/core/src/test/java/org/dozer/functional_tests/ClassloaderTest.java
+++ b/core/src/test/java/org/dozer/functional_tests/ClassloaderTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/functional_tests/CollectionTest.java
+++ b/core/src/test/java/org/dozer/functional_tests/CollectionTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/functional_tests/ConstructorTest.java
+++ b/core/src/test/java/org/dozer/functional_tests/ConstructorTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/functional_tests/CopyByReferenceCollectionTest.java
+++ b/core/src/test/java/org/dozer/functional_tests/CopyByReferenceCollectionTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/functional_tests/CopyByReferenceFromMapTest.java
+++ b/core/src/test/java/org/dozer/functional_tests/CopyByReferenceFromMapTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/functional_tests/CumulativeCollectionMappingTest.java
+++ b/core/src/test/java/org/dozer/functional_tests/CumulativeCollectionMappingTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/functional_tests/CumulativeMappingTest.java
+++ b/core/src/test/java/org/dozer/functional_tests/CumulativeMappingTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/functional_tests/CustomConverterMapperAwareTest.java
+++ b/core/src/test/java/org/dozer/functional_tests/CustomConverterMapperAwareTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/functional_tests/CustomConverterMappingTest.java
+++ b/core/src/test/java/org/dozer/functional_tests/CustomConverterMappingTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/functional_tests/CustomConverterParamMappingTest.java
+++ b/core/src/test/java/org/dozer/functional_tests/CustomConverterParamMappingTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/functional_tests/DataObjectInstantiator.java
+++ b/core/src/test/java/org/dozer/functional_tests/DataObjectInstantiator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/functional_tests/DateFormatTest.java
+++ b/core/src/test/java/org/dozer/functional_tests/DateFormatTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/functional_tests/DeepMappingTest.java
+++ b/core/src/test/java/org/dozer/functional_tests/DeepMappingTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/functional_tests/DeepMappingWithIndexTest.java
+++ b/core/src/test/java/org/dozer/functional_tests/DeepMappingWithIndexTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/functional_tests/DozerBeanMapperTest.java
+++ b/core/src/test/java/org/dozer/functional_tests/DozerBeanMapperTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/functional_tests/DynamicMethod.java
+++ b/core/src/test/java/org/dozer/functional_tests/DynamicMethod.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2014 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/functional_tests/EnumMappingTest.java
+++ b/core/src/test/java/org/dozer/functional_tests/EnumMappingTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/functional_tests/ExceptionHandlingFunctionalTest.java
+++ b/core/src/test/java/org/dozer/functional_tests/ExceptionHandlingFunctionalTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/functional_tests/ExcludeFieldTest.java
+++ b/core/src/test/java/org/dozer/functional_tests/ExcludeFieldTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/functional_tests/GenericCollectionMappingTest.java
+++ b/core/src/test/java/org/dozer/functional_tests/GenericCollectionMappingTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/functional_tests/GenericListFunctionalTest.java
+++ b/core/src/test/java/org/dozer/functional_tests/GenericListFunctionalTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/functional_tests/GenericsTest.java
+++ b/core/src/test/java/org/dozer/functional_tests/GenericsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/functional_tests/GlobalReferenceTest.java
+++ b/core/src/test/java/org/dozer/functional_tests/GlobalReferenceTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/functional_tests/GrandparentTest.java
+++ b/core/src/test/java/org/dozer/functional_tests/GrandparentTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/functional_tests/GranularDozerBeanMapperTest.java
+++ b/core/src/test/java/org/dozer/functional_tests/GranularDozerBeanMapperTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/functional_tests/IndexMappingTest.java
+++ b/core/src/test/java/org/dozer/functional_tests/IndexMappingTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/functional_tests/IneritanceHintSupportTest.java
+++ b/core/src/test/java/org/dozer/functional_tests/IneritanceHintSupportTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/functional_tests/InheritanceAbstractClassMappingTest.java
+++ b/core/src/test/java/org/dozer/functional_tests/InheritanceAbstractClassMappingTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/functional_tests/InheritanceCustomConverterTest.java
+++ b/core/src/test/java/org/dozer/functional_tests/InheritanceCustomConverterTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/functional_tests/InheritanceDirectionTest.java
+++ b/core/src/test/java/org/dozer/functional_tests/InheritanceDirectionTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/functional_tests/InheritanceMappingMapBackedTest.java
+++ b/core/src/test/java/org/dozer/functional_tests/InheritanceMappingMapBackedTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/functional_tests/InheritanceMappingTest.java
+++ b/core/src/test/java/org/dozer/functional_tests/InheritanceMappingTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/functional_tests/InheritanceTwoLevelTest.java
+++ b/core/src/test/java/org/dozer/functional_tests/InheritanceTwoLevelTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/functional_tests/InterfacePerformanceTest.java
+++ b/core/src/test/java/org/dozer/functional_tests/InterfacePerformanceTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/functional_tests/InvalidMappingTest.java
+++ b/core/src/test/java/org/dozer/functional_tests/InvalidMappingTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/functional_tests/IsAccessibleTest.java
+++ b/core/src/test/java/org/dozer/functional_tests/IsAccessibleTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/functional_tests/JAXBBeansMappingTest.java
+++ b/core/src/test/java/org/dozer/functional_tests/JAXBBeansMappingTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/functional_tests/KnownFailures.java
+++ b/core/src/test/java/org/dozer/functional_tests/KnownFailures.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/functional_tests/MapBackedDeepMappingTest.java
+++ b/core/src/test/java/org/dozer/functional_tests/MapBackedDeepMappingTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/functional_tests/MapIdSameInstanceTest.java
+++ b/core/src/test/java/org/dozer/functional_tests/MapIdSameInstanceTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2005-2017 Dozer Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.dozer.functional_tests;
 
 import org.dozer.vo.mapidsameinstance.One;

--- a/core/src/test/java/org/dozer/functional_tests/MapIdTest.java
+++ b/core/src/test/java/org/dozer/functional_tests/MapIdTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/functional_tests/MapMappingTest.java
+++ b/core/src/test/java/org/dozer/functional_tests/MapMappingTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/functional_tests/MapTypeTest.java
+++ b/core/src/test/java/org/dozer/functional_tests/MapTypeTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/functional_tests/MapperTest.java
+++ b/core/src/test/java/org/dozer/functional_tests/MapperTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/functional_tests/MetadataFieldTest.java
+++ b/core/src/test/java/org/dozer/functional_tests/MetadataFieldTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/functional_tests/MetadataTest.java
+++ b/core/src/test/java/org/dozer/functional_tests/MetadataTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/functional_tests/MultiThreadedTest.java
+++ b/core/src/test/java/org/dozer/functional_tests/MultiThreadedTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/functional_tests/MultipleHintsTest.java
+++ b/core/src/test/java/org/dozer/functional_tests/MultipleHintsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/functional_tests/NewCustomConverterTest.java
+++ b/core/src/test/java/org/dozer/functional_tests/NewCustomConverterTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/functional_tests/NullMappingTest.java
+++ b/core/src/test/java/org/dozer/functional_tests/NullMappingTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/functional_tests/OneWayMappingTest.java
+++ b/core/src/test/java/org/dozer/functional_tests/OneWayMappingTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/functional_tests/PerformanceTest.java
+++ b/core/src/test/java/org/dozer/functional_tests/PerformanceTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/functional_tests/RecursiveInterfaceMappingTest.java
+++ b/core/src/test/java/org/dozer/functional_tests/RecursiveInterfaceMappingTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/functional_tests/RecursiveSelfMappingTest.java
+++ b/core/src/test/java/org/dozer/functional_tests/RecursiveSelfMappingTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/functional_tests/RecursiveTest.java
+++ b/core/src/test/java/org/dozer/functional_tests/RecursiveTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/functional_tests/RuntimeSubclassMappingTest.java
+++ b/core/src/test/java/org/dozer/functional_tests/RuntimeSubclassMappingTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/functional_tests/SubclassReferenceTest.java
+++ b/core/src/test/java/org/dozer/functional_tests/SubclassReferenceTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/functional_tests/SuperInterfaceMappingTest.java
+++ b/core/src/test/java/org/dozer/functional_tests/SuperInterfaceMappingTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/functional_tests/TopLevelMappingTest.java
+++ b/core/src/test/java/org/dozer/functional_tests/TopLevelMappingTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/functional_tests/TrimStringsTest.java
+++ b/core/src/test/java/org/dozer/functional_tests/TrimStringsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/functional_tests/UUIDMappingTest.java
+++ b/core/src/test/java/org/dozer/functional_tests/UUIDMappingTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2005-2017 Dozer Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.dozer.functional_tests;
 
 import org.junit.Test;

--- a/core/src/test/java/org/dozer/functional_tests/UntypedCollectionTest.java
+++ b/core/src/test/java/org/dozer/functional_tests/UntypedCollectionTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/functional_tests/VariablesTest.java
+++ b/core/src/test/java/org/dozer/functional_tests/VariablesTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/functional_tests/WildcardWrapperTypeTest.java
+++ b/core/src/test/java/org/dozer/functional_tests/WildcardWrapperTypeTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2014 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/functional_tests/XMLBeansMappingTest.java
+++ b/core/src/test/java/org/dozer/functional_tests/XMLBeansMappingTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/functional_tests/annotation/AnnotationMappingTest.java
+++ b/core/src/test/java/org/dozer/functional_tests/annotation/AnnotationMappingTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/functional_tests/builder/CollectionWithNullTest.java
+++ b/core/src/test/java/org/dozer/functional_tests/builder/CollectionWithNullTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/functional_tests/builder/DeepMappingWithMapIdTest.java
+++ b/core/src/test/java/org/dozer/functional_tests/builder/DeepMappingWithMapIdTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2005-2017 Dozer Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.dozer.functional_tests.builder;
 
 import java.util.ArrayList;

--- a/core/src/test/java/org/dozer/functional_tests/builder/DozerBuilderTest.java
+++ b/core/src/test/java/org/dozer/functional_tests/builder/DozerBuilderTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/functional_tests/builder/GenericsTest.java
+++ b/core/src/test/java/org/dozer/functional_tests/builder/GenericsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/functional_tests/builder/InheritanceTest.java
+++ b/core/src/test/java/org/dozer/functional_tests/builder/InheritanceTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/functional_tests/builder/MapMappingTest.java
+++ b/core/src/test/java/org/dozer/functional_tests/builder/MapMappingTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/functional_tests/builder/MapNullTest.java
+++ b/core/src/test/java/org/dozer/functional_tests/builder/MapNullTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/functional_tests/builder/PrimitiveTest.java
+++ b/core/src/test/java/org/dozer/functional_tests/builder/PrimitiveTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/functional_tests/builder/SimpleTest.java
+++ b/core/src/test/java/org/dozer/functional_tests/builder/SimpleTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/functional_tests/mapperaware/BidirectionalMany.java
+++ b/core/src/test/java/org/dozer/functional_tests/mapperaware/BidirectionalMany.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/functional_tests/mapperaware/BidirectionalManyConvert.java
+++ b/core/src/test/java/org/dozer/functional_tests/mapperaware/BidirectionalManyConvert.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/functional_tests/mapperaware/BidirectionalOne.java
+++ b/core/src/test/java/org/dozer/functional_tests/mapperaware/BidirectionalOne.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/functional_tests/mapperaware/BidirectionalOneConvert.java
+++ b/core/src/test/java/org/dozer/functional_tests/mapperaware/BidirectionalOneConvert.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/functional_tests/mapperaware/CachingCustomConverterTest.java
+++ b/core/src/test/java/org/dozer/functional_tests/mapperaware/CachingCustomConverterTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/functional_tests/mapperaware/SecondUsingMapInternalTest.java
+++ b/core/src/test/java/org/dozer/functional_tests/mapperaware/SecondUsingMapInternalTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/functional_tests/runner/InstantiatorHolder.java
+++ b/core/src/test/java/org/dozer/functional_tests/runner/InstantiatorHolder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/functional_tests/runner/JavassistDataObjectInstantiator.java
+++ b/core/src/test/java/org/dozer/functional_tests/runner/JavassistDataObjectInstantiator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/functional_tests/runner/NoProxyDataObjectInstantiator.java
+++ b/core/src/test/java/org/dozer/functional_tests/runner/NoProxyDataObjectInstantiator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/functional_tests/runner/Proxied.java
+++ b/core/src/test/java/org/dozer/functional_tests/runner/Proxied.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/functional_tests/runner/ProxyDataObjectInstantiator.java
+++ b/core/src/test/java/org/dozer/functional_tests/runner/ProxyDataObjectInstantiator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/functional_tests/runner/ProxyRunner.java
+++ b/core/src/test/java/org/dozer/functional_tests/runner/ProxyRunner.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/functional_tests/support/BaseSampleBeanFactory.java
+++ b/core/src/test/java/org/dozer/functional_tests/support/BaseSampleBeanFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/functional_tests/support/CustomConverterParamConverter.java
+++ b/core/src/test/java/org/dozer/functional_tests/support/CustomConverterParamConverter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/functional_tests/support/HintedOnlyConverter.java
+++ b/core/src/test/java/org/dozer/functional_tests/support/HintedOnlyConverter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/functional_tests/support/InjectedCustomConverter.java
+++ b/core/src/test/java/org/dozer/functional_tests/support/InjectedCustomConverter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/functional_tests/support/MyDozerConverter.java
+++ b/core/src/test/java/org/dozer/functional_tests/support/MyDozerConverter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/functional_tests/support/SampleCustomBeanFactory.java
+++ b/core/src/test/java/org/dozer/functional_tests/support/SampleCustomBeanFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/functional_tests/support/SampleCustomBeanFactory2.java
+++ b/core/src/test/java/org/dozer/functional_tests/support/SampleCustomBeanFactory2.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/functional_tests/support/SampleCustomBeanFactory3.java
+++ b/core/src/test/java/org/dozer/functional_tests/support/SampleCustomBeanFactory3.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/functional_tests/support/SampleDefaultBeanFactory.java
+++ b/core/src/test/java/org/dozer/functional_tests/support/SampleDefaultBeanFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/functional_tests/support/StringAppendCustomConverter.java
+++ b/core/src/test/java/org/dozer/functional_tests/support/StringAppendCustomConverter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/functional_tests/support/TestCustomConverter.java
+++ b/core/src/test/java/org/dozer/functional_tests/support/TestCustomConverter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/functional_tests/support/TestCustomFieldMapper.java
+++ b/core/src/test/java/org/dozer/functional_tests/support/TestCustomFieldMapper.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/functional_tests/support/TestCustomHashMapConverter.java
+++ b/core/src/test/java/org/dozer/functional_tests/support/TestCustomHashMapConverter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/functional_tests/support/TestDataFactory.java
+++ b/core/src/test/java/org/dozer/functional_tests/support/TestDataFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/functional_tests/support/ThrowExceptionCustomConverter.java
+++ b/core/src/test/java/org/dozer/functional_tests/support/ThrowExceptionCustomConverter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/functional_tests/support/UserBeanFactory.java
+++ b/core/src/test/java/org/dozer/functional_tests/support/UserBeanFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/inject/DozerBeanContainerTest.java
+++ b/core/src/test/java/org/dozer/inject/DozerBeanContainerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/jmx/DozerAdminControllerTest.java
+++ b/core/src/test/java/org/dozer/jmx/DozerAdminControllerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/jmx/DozerStatisticsControllerTest.java
+++ b/core/src/test/java/org/dozer/jmx/DozerStatisticsControllerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/jmx/JMXPlatformImplTest.java
+++ b/core/src/test/java/org/dozer/jmx/JMXPlatformImplTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/loader/CustomMappingsLoaderTest.java
+++ b/core/src/test/java/org/dozer/loader/CustomMappingsLoaderTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/loader/MappingsBuilderTest.java
+++ b/core/src/test/java/org/dozer/loader/MappingsBuilderTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/loader/MappingsParserTest.java
+++ b/core/src/test/java/org/dozer/loader/MappingsParserTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/loader/api/FieldsMappingOptionsTest.java
+++ b/core/src/test/java/org/dozer/loader/api/FieldsMappingOptionsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/loader/xml/DozerResolverTest.java
+++ b/core/src/test/java/org/dozer/loader/xml/DozerResolverTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/loader/xml/ELEngineTest.java
+++ b/core/src/test/java/org/dozer/loader/xml/ELEngineTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/loader/xml/MappingFileReaderTest.java
+++ b/core/src/test/java/org/dozer/loader/xml/MappingFileReaderTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/loader/xml/MappingStreamReaderTest.java
+++ b/core/src/test/java/org/dozer/loader/xml/MappingStreamReaderTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/loader/xml/SimpleElementReaderTest.java
+++ b/core/src/test/java/org/dozer/loader/xml/SimpleElementReaderTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/loader/xml/XMLParserTest.java
+++ b/core/src/test/java/org/dozer/loader/xml/XMLParserTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/propertydescriptor/FieldPropertyDescriptorTest.java
+++ b/core/src/test/java/org/dozer/propertydescriptor/FieldPropertyDescriptorTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/propertydescriptor/GetterSetterPropertyDescriptorTest.java
+++ b/core/src/test/java/org/dozer/propertydescriptor/GetterSetterPropertyDescriptorTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/propertydescriptor/GetterSetterPropertyDescriptorWithGenericSuperClassTest.java
+++ b/core/src/test/java/org/dozer/propertydescriptor/GetterSetterPropertyDescriptorWithGenericSuperClassTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/propertydescriptor/MapPropertyDescriptorTest.java
+++ b/core/src/test/java/org/dozer/propertydescriptor/MapPropertyDescriptorTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/stats/GlobalStatisticsTest.java
+++ b/core/src/test/java/org/dozer/stats/GlobalStatisticsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/stats/StatisticEntryTest.java
+++ b/core/src/test/java/org/dozer/stats/StatisticEntryTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/stats/StatisticManagerTest.java
+++ b/core/src/test/java/org/dozer/stats/StatisticManagerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/stats/StatisticTest.java
+++ b/core/src/test/java/org/dozer/stats/StatisticTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/stats/StatisticsInterceptorTest.java
+++ b/core/src/test/java/org/dozer/stats/StatisticsInterceptorTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/util/CollectionUtilsTest.java
+++ b/core/src/test/java/org/dozer/util/CollectionUtilsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/util/DefaultProxyResolverTest.java
+++ b/core/src/test/java/org/dozer/util/DefaultProxyResolverTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/util/IteratorUtilsTest.java
+++ b/core/src/test/java/org/dozer/util/IteratorUtilsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/util/MappingUtilsTest.java
+++ b/core/src/test/java/org/dozer/util/MappingUtilsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/util/MappingValidatorTest.java
+++ b/core/src/test/java/org/dozer/util/MappingValidatorTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/util/ReflectionUtilsTest.java
+++ b/core/src/test/java/org/dozer/util/ReflectionUtilsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/util/ResourceLoaderTest.java
+++ b/core/src/test/java/org/dozer/util/ResourceLoaderTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/A.java
+++ b/core/src/test/java/org/dozer/vo/A.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/Aliases.java
+++ b/core/src/test/java/org/dozer/vo/Aliases.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/AnotherTestObject.java
+++ b/core/src/test/java/org/dozer/vo/AnotherTestObject.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/AnotherTestObjectPrime.java
+++ b/core/src/test/java/org/dozer/vo/AnotherTestObjectPrime.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/Apple.java
+++ b/core/src/test/java/org/dozer/vo/Apple.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/AppleComputer.java
+++ b/core/src/test/java/org/dozer/vo/AppleComputer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/ArrayCustConverterObj.java
+++ b/core/src/test/java/org/dozer/vo/ArrayCustConverterObj.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/ArrayCustConverterObjPrime.java
+++ b/core/src/test/java/org/dozer/vo/ArrayCustConverterObjPrime.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/ArrayDest.java
+++ b/core/src/test/java/org/dozer/vo/ArrayDest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/ArraySource.java
+++ b/core/src/test/java/org/dozer/vo/ArraySource.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/B.java
+++ b/core/src/test/java/org/dozer/vo/B.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/BaseTestObject.java
+++ b/core/src/test/java/org/dozer/vo/BaseTestObject.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/Bus.java
+++ b/core/src/test/java/org/dozer/vo/Bus.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/C.java
+++ b/core/src/test/java/org/dozer/vo/C.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/CToStringConverter.java
+++ b/core/src/test/java/org/dozer/vo/CToStringConverter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/Car.java
+++ b/core/src/test/java/org/dozer/vo/Car.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/Child.java
+++ b/core/src/test/java/org/dozer/vo/Child.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/CustomConverterWrapper.java
+++ b/core/src/test/java/org/dozer/vo/CustomConverterWrapper.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/CustomConverterWrapperPrime.java
+++ b/core/src/test/java/org/dozer/vo/CustomConverterWrapperPrime.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/CustomDoubleObject.java
+++ b/core/src/test/java/org/dozer/vo/CustomDoubleObject.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/CustomDoubleObjectIF.java
+++ b/core/src/test/java/org/dozer/vo/CustomDoubleObjectIF.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/CustomGetDest.java
+++ b/core/src/test/java/org/dozer/vo/CustomGetDest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/CustomGetSource.java
+++ b/core/src/test/java/org/dozer/vo/CustomGetSource.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/D.java
+++ b/core/src/test/java/org/dozer/vo/D.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/DateContainer.java
+++ b/core/src/test/java/org/dozer/vo/DateContainer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/DateObjectDest.java
+++ b/core/src/test/java/org/dozer/vo/DateObjectDest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/DateObjectSource.java
+++ b/core/src/test/java/org/dozer/vo/DateObjectSource.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/DeepObject.java
+++ b/core/src/test/java/org/dozer/vo/DeepObject.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/DehydrateTestObject.java
+++ b/core/src/test/java/org/dozer/vo/DehydrateTestObject.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/DoubleObject.java
+++ b/core/src/test/java/org/dozer/vo/DoubleObject.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/FieldValue.java
+++ b/core/src/test/java/org/dozer/vo/FieldValue.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/FlatIndividual.java
+++ b/core/src/test/java/org/dozer/vo/FlatIndividual.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/Fruit.java
+++ b/core/src/test/java/org/dozer/vo/Fruit.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/FurtherTestObject.java
+++ b/core/src/test/java/org/dozer/vo/FurtherTestObject.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/FurtherTestObjectPrime.java
+++ b/core/src/test/java/org/dozer/vo/FurtherTestObjectPrime.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/HintedOnly.java
+++ b/core/src/test/java/org/dozer/vo/HintedOnly.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/HydrateTestObject.java
+++ b/core/src/test/java/org/dozer/vo/HydrateTestObject.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/HydrateTestObject2.java
+++ b/core/src/test/java/org/dozer/vo/HydrateTestObject2.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/HydrateTestObject3.java
+++ b/core/src/test/java/org/dozer/vo/HydrateTestObject3.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/HydrateTestObject4.java
+++ b/core/src/test/java/org/dozer/vo/HydrateTestObject4.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/HydrateTestObject5.java
+++ b/core/src/test/java/org/dozer/vo/HydrateTestObject5.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/Individual.java
+++ b/core/src/test/java/org/dozer/vo/Individual.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/Individuals.java
+++ b/core/src/test/java/org/dozer/vo/Individuals.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/InsideTestObject.java
+++ b/core/src/test/java/org/dozer/vo/InsideTestObject.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/InsideTestObjectPrime.java
+++ b/core/src/test/java/org/dozer/vo/InsideTestObjectPrime.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/LoopObjectChild.java
+++ b/core/src/test/java/org/dozer/vo/LoopObjectChild.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/LoopObjectChildPrime.java
+++ b/core/src/test/java/org/dozer/vo/LoopObjectChildPrime.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/LoopObjectParent.java
+++ b/core/src/test/java/org/dozer/vo/LoopObjectParent.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/LoopObjectParentPrime.java
+++ b/core/src/test/java/org/dozer/vo/LoopObjectParentPrime.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/MessageHeaderDTO.java
+++ b/core/src/test/java/org/dozer/vo/MessageHeaderDTO.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/MessageHeaderVO.java
+++ b/core/src/test/java/org/dozer/vo/MessageHeaderVO.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/MessageIdList.java
+++ b/core/src/test/java/org/dozer/vo/MessageIdList.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/MessageIdVO.java
+++ b/core/src/test/java/org/dozer/vo/MessageIdVO.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/MetalThingyIF.java
+++ b/core/src/test/java/org/dozer/vo/MetalThingyIF.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/MethodFieldTestObject.java
+++ b/core/src/test/java/org/dozer/vo/MethodFieldTestObject.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/MethodFieldTestObject2.java
+++ b/core/src/test/java/org/dozer/vo/MethodFieldTestObject2.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/Moped.java
+++ b/core/src/test/java/org/dozer/vo/Moped.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/MyPrimitiveWrapper.java
+++ b/core/src/test/java/org/dozer/vo/MyPrimitiveWrapper.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/NoCustomMappingsObject.java
+++ b/core/src/test/java/org/dozer/vo/NoCustomMappingsObject.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/NoCustomMappingsObjectPrime.java
+++ b/core/src/test/java/org/dozer/vo/NoCustomMappingsObjectPrime.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/NoDefaultConstructor.java
+++ b/core/src/test/java/org/dozer/vo/NoDefaultConstructor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/NoExtendBaseObject.java
+++ b/core/src/test/java/org/dozer/vo/NoExtendBaseObject.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/NoExtendBaseObjectGlobalCopyByReference.java
+++ b/core/src/test/java/org/dozer/vo/NoExtendBaseObjectGlobalCopyByReference.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/NoReadMethod.java
+++ b/core/src/test/java/org/dozer/vo/NoReadMethod.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/NoReadMethodPrime.java
+++ b/core/src/test/java/org/dozer/vo/NoReadMethodPrime.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/NoSuperClass.java
+++ b/core/src/test/java/org/dozer/vo/NoSuperClass.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/NoVoidSetters.java
+++ b/core/src/test/java/org/dozer/vo/NoVoidSetters.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/NoWriteMethod.java
+++ b/core/src/test/java/org/dozer/vo/NoWriteMethod.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/NoWriteMethodPrime.java
+++ b/core/src/test/java/org/dozer/vo/NoWriteMethodPrime.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/OneWayObject.java
+++ b/core/src/test/java/org/dozer/vo/OneWayObject.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/OneWayObjectPrime.java
+++ b/core/src/test/java/org/dozer/vo/OneWayObjectPrime.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/Orange.java
+++ b/core/src/test/java/org/dozer/vo/Orange.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/Person1.java
+++ b/core/src/test/java/org/dozer/vo/Person1.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/Person2.java
+++ b/core/src/test/java/org/dozer/vo/Person2.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/PersonName.java
+++ b/core/src/test/java/org/dozer/vo/PersonName.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/PrimitiveArrayObj.java
+++ b/core/src/test/java/org/dozer/vo/PrimitiveArrayObj.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/PrimitiveArrayObjPrime.java
+++ b/core/src/test/java/org/dozer/vo/PrimitiveArrayObjPrime.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/SimpleEnum.java
+++ b/core/src/test/java/org/dozer/vo/SimpleEnum.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/SimpleObj.java
+++ b/core/src/test/java/org/dozer/vo/SimpleObj.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/SimpleObjPrime.java
+++ b/core/src/test/java/org/dozer/vo/SimpleObjPrime.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/SimpleObjPrime2.java
+++ b/core/src/test/java/org/dozer/vo/SimpleObjPrime2.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/SubClass.java
+++ b/core/src/test/java/org/dozer/vo/SubClass.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/SubClassPrime.java
+++ b/core/src/test/java/org/dozer/vo/SubClassPrime.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/SuperClass.java
+++ b/core/src/test/java/org/dozer/vo/SuperClass.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/SuperClassPrime.java
+++ b/core/src/test/java/org/dozer/vo/SuperClassPrime.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/SuperSuperClass.java
+++ b/core/src/test/java/org/dozer/vo/SuperSuperClass.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/SuperSuperClassPrime.java
+++ b/core/src/test/java/org/dozer/vo/SuperSuperClassPrime.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/SuperSuperSuperClass.java
+++ b/core/src/test/java/org/dozer/vo/SuperSuperSuperClass.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/SuperSuperSuperClassPrime.java
+++ b/core/src/test/java/org/dozer/vo/SuperSuperSuperClassPrime.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/TestCustomConverterHashMapObject.java
+++ b/core/src/test/java/org/dozer/vo/TestCustomConverterHashMapObject.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/TestCustomConverterHashMapPrimeObject.java
+++ b/core/src/test/java/org/dozer/vo/TestCustomConverterHashMapPrimeObject.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/TestCustomConverterObject.java
+++ b/core/src/test/java/org/dozer/vo/TestCustomConverterObject.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/TestCustomConverterObjectPrime.java
+++ b/core/src/test/java/org/dozer/vo/TestCustomConverterObjectPrime.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/TestObject.java
+++ b/core/src/test/java/org/dozer/vo/TestObject.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/TestObjectPrime.java
+++ b/core/src/test/java/org/dozer/vo/TestObjectPrime.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/TestObjectPrime2.java
+++ b/core/src/test/java/org/dozer/vo/TestObjectPrime2.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/TestReferenceFoo.java
+++ b/core/src/test/java/org/dozer/vo/TestReferenceFoo.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/TestReferenceFooPrime.java
+++ b/core/src/test/java/org/dozer/vo/TestReferenceFooPrime.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/TestReferenceObject.java
+++ b/core/src/test/java/org/dozer/vo/TestReferenceObject.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/TestReferencePrimeObject.java
+++ b/core/src/test/java/org/dozer/vo/TestReferencePrimeObject.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/TheFirstSubClass.java
+++ b/core/src/test/java/org/dozer/vo/TheFirstSubClass.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/TheFirstSubClassPrime.java
+++ b/core/src/test/java/org/dozer/vo/TheFirstSubClassPrime.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/TheSecondSubClass.java
+++ b/core/src/test/java/org/dozer/vo/TheSecondSubClass.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/TheSecondSubClassPrime.java
+++ b/core/src/test/java/org/dozer/vo/TheSecondSubClassPrime.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/TheSuperType.java
+++ b/core/src/test/java/org/dozer/vo/TheSuperType.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/ValueObject.java
+++ b/core/src/test/java/org/dozer/vo/ValueObject.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/Van.java
+++ b/core/src/test/java/org/dozer/vo/Van.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/Vehicle.java
+++ b/core/src/test/java/org/dozer/vo/Vehicle.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/WeirdGetter.java
+++ b/core/src/test/java/org/dozer/vo/WeirdGetter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/WeirdGetter2.java
+++ b/core/src/test/java/org/dozer/vo/WeirdGetter2.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/WeirdGetterPrime.java
+++ b/core/src/test/java/org/dozer/vo/WeirdGetterPrime.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/WeirdGetterPrime2.java
+++ b/core/src/test/java/org/dozer/vo/WeirdGetterPrime2.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/abstractinheritance/A.java
+++ b/core/src/test/java/org/dozer/vo/abstractinheritance/A.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/abstractinheritance/AbstractA.java
+++ b/core/src/test/java/org/dozer/vo/abstractinheritance/AbstractA.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/abstractinheritance/AbstractACollectionContainer.java
+++ b/core/src/test/java/org/dozer/vo/abstractinheritance/AbstractACollectionContainer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/abstractinheritance/AbstractAContainer.java
+++ b/core/src/test/java/org/dozer/vo/abstractinheritance/AbstractAContainer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/abstractinheritance/AbstractB.java
+++ b/core/src/test/java/org/dozer/vo/abstractinheritance/AbstractB.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/abstractinheritance/AbstractBCollectionContainer.java
+++ b/core/src/test/java/org/dozer/vo/abstractinheritance/AbstractBCollectionContainer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/abstractinheritance/AbstractBContainer.java
+++ b/core/src/test/java/org/dozer/vo/abstractinheritance/AbstractBContainer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/abstractinheritance/B.java
+++ b/core/src/test/java/org/dozer/vo/abstractinheritance/B.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/abstractinheritance/C.java
+++ b/core/src/test/java/org/dozer/vo/abstractinheritance/C.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/allowedexceptions/TestException.java
+++ b/core/src/test/java/org/dozer/vo/allowedexceptions/TestException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/allowedexceptions/ThrowException.java
+++ b/core/src/test/java/org/dozer/vo/allowedexceptions/ThrowException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/allowedexceptions/ThrowExceptionPrime.java
+++ b/core/src/test/java/org/dozer/vo/allowedexceptions/ThrowExceptionPrime.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/bidirectional/A.java
+++ b/core/src/test/java/org/dozer/vo/bidirectional/A.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/bidirectional/B.java
+++ b/core/src/test/java/org/dozer/vo/bidirectional/B.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/collections/User.java
+++ b/core/src/test/java/org/dozer/vo/collections/User.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/collections/UserGroup.java
+++ b/core/src/test/java/org/dozer/vo/collections/UserGroup.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/collections/UserGroupImpl.java
+++ b/core/src/test/java/org/dozer/vo/collections/UserGroupImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/collections/UserGroupPrime.java
+++ b/core/src/test/java/org/dozer/vo/collections/UserGroupPrime.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/collections/UserImpl.java
+++ b/core/src/test/java/org/dozer/vo/collections/UserImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/collections/UserPrime.java
+++ b/core/src/test/java/org/dozer/vo/collections/UserPrime.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/context/ContextMapping.java
+++ b/core/src/test/java/org/dozer/vo/context/ContextMapping.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/context/ContextMappingNested.java
+++ b/core/src/test/java/org/dozer/vo/context/ContextMappingNested.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/context/ContextMappingNestedPrime.java
+++ b/core/src/test/java/org/dozer/vo/context/ContextMappingNestedPrime.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/context/ContextMappingPrime.java
+++ b/core/src/test/java/org/dozer/vo/context/ContextMappingPrime.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/copybyreference/Reference.java
+++ b/core/src/test/java/org/dozer/vo/copybyreference/Reference.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/copybyreference/TestA.java
+++ b/core/src/test/java/org/dozer/vo/copybyreference/TestA.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/copybyreference/TestB.java
+++ b/core/src/test/java/org/dozer/vo/copybyreference/TestB.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/cumulative/Author.java
+++ b/core/src/test/java/org/dozer/vo/cumulative/Author.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/cumulative/AuthorPrime.java
+++ b/core/src/test/java/org/dozer/vo/cumulative/AuthorPrime.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/cumulative/Book.java
+++ b/core/src/test/java/org/dozer/vo/cumulative/Book.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/cumulative/BookPrime.java
+++ b/core/src/test/java/org/dozer/vo/cumulative/BookPrime.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/cumulative/Library.java
+++ b/core/src/test/java/org/dozer/vo/cumulative/Library.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/cumulative/LibraryPrime.java
+++ b/core/src/test/java/org/dozer/vo/cumulative/LibraryPrime.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/deep/Address.java
+++ b/core/src/test/java/org/dozer/vo/deep/Address.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/deep/City.java
+++ b/core/src/test/java/org/dozer/vo/deep/City.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/deep/Description.java
+++ b/core/src/test/java/org/dozer/vo/deep/Description.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/deep/DestDeepObj.java
+++ b/core/src/test/java/org/dozer/vo/deep/DestDeepObj.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/deep/HomeDescription.java
+++ b/core/src/test/java/org/dozer/vo/deep/HomeDescription.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/deep/House.java
+++ b/core/src/test/java/org/dozer/vo/deep/House.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/deep/Person.java
+++ b/core/src/test/java/org/dozer/vo/deep/Person.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/deep/Room.java
+++ b/core/src/test/java/org/dozer/vo/deep/Room.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/deep/SrcDeepObj.java
+++ b/core/src/test/java/org/dozer/vo/deep/SrcDeepObj.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/deep/SrcNestedDeepObj.java
+++ b/core/src/test/java/org/dozer/vo/deep/SrcNestedDeepObj.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/deep/SrcNestedDeepObj2.java
+++ b/core/src/test/java/org/dozer/vo/deep/SrcNestedDeepObj2.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/deep2/Dest.java
+++ b/core/src/test/java/org/dozer/vo/deep2/Dest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/deep2/NestedDest.java
+++ b/core/src/test/java/org/dozer/vo/deep2/NestedDest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/deep2/NestedNestedDest.java
+++ b/core/src/test/java/org/dozer/vo/deep2/NestedNestedDest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/deep2/Src.java
+++ b/core/src/test/java/org/dozer/vo/deep2/Src.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/deep3/AbstractDest.java
+++ b/core/src/test/java/org/dozer/vo/deep3/AbstractDest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/deep3/Dest.java
+++ b/core/src/test/java/org/dozer/vo/deep3/Dest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/deep3/NestedDest.java
+++ b/core/src/test/java/org/dozer/vo/deep3/NestedDest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/deep3/NestedNestedDest.java
+++ b/core/src/test/java/org/dozer/vo/deep3/NestedNestedDest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/deepindex/A.java
+++ b/core/src/test/java/org/dozer/vo/deepindex/A.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/deepindex/B.java
+++ b/core/src/test/java/org/dozer/vo/deepindex/B.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/deepindex/C.java
+++ b/core/src/test/java/org/dozer/vo/deepindex/C.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/deepindex/Family.java
+++ b/core/src/test/java/org/dozer/vo/deepindex/Family.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/deepindex/HeadOfHouseHold.java
+++ b/core/src/test/java/org/dozer/vo/deepindex/HeadOfHouseHold.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/deepindex/HeadOfHouseHolds.java
+++ b/core/src/test/java/org/dozer/vo/deepindex/HeadOfHouseHolds.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/deepindex/HeadOfHouseHoldsContainer.java
+++ b/core/src/test/java/org/dozer/vo/deepindex/HeadOfHouseHoldsContainer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/deepindex/PersonalDetails.java
+++ b/core/src/test/java/org/dozer/vo/deepindex/PersonalDetails.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/deepindex/Pet.java
+++ b/core/src/test/java/org/dozer/vo/deepindex/Pet.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/deepindex/customconverter/Conv.java
+++ b/core/src/test/java/org/dozer/vo/deepindex/customconverter/Conv.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/deepindex/customconverter/First.java
+++ b/core/src/test/java/org/dozer/vo/deepindex/customconverter/First.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/deepindex/customconverter/Fourth.java
+++ b/core/src/test/java/org/dozer/vo/deepindex/customconverter/Fourth.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/deepindex/customconverter/Last.java
+++ b/core/src/test/java/org/dozer/vo/deepindex/customconverter/Last.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/deepindex/customconverter/Second.java
+++ b/core/src/test/java/org/dozer/vo/deepindex/customconverter/Second.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/deepindex/customconverter/Third.java
+++ b/core/src/test/java/org/dozer/vo/deepindex/customconverter/Third.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/deepindex/isaccessible/FlatPerson.java
+++ b/core/src/test/java/org/dozer/vo/deepindex/isaccessible/FlatPerson.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/deepindex/isaccessible/Person.java
+++ b/core/src/test/java/org/dozer/vo/deepindex/isaccessible/Person.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/deepindex/isaccessible/Phone.java
+++ b/core/src/test/java/org/dozer/vo/deepindex/isaccessible/Phone.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/direction/ContentItemGroup.java
+++ b/core/src/test/java/org/dozer/vo/direction/ContentItemGroup.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/direction/ContentItemGroupBase.java
+++ b/core/src/test/java/org/dozer/vo/direction/ContentItemGroupBase.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/direction/ContentItemGroupDTO.java
+++ b/core/src/test/java/org/dozer/vo/direction/ContentItemGroupDTO.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/direction/ContentItemGroupDefault.java
+++ b/core/src/test/java/org/dozer/vo/direction/ContentItemGroupDefault.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/direction/Entity.java
+++ b/core/src/test/java/org/dozer/vo/direction/Entity.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/direction/EntityBase.java
+++ b/core/src/test/java/org/dozer/vo/direction/EntityBase.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/direction/EntityDTO.java
+++ b/core/src/test/java/org/dozer/vo/direction/EntityDTO.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/enumtest/DestType.java
+++ b/core/src/test/java/org/dozer/vo/enumtest/DestType.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/enumtest/DestTypeWithOverride.java
+++ b/core/src/test/java/org/dozer/vo/enumtest/DestTypeWithOverride.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/enumtest/MyBean.java
+++ b/core/src/test/java/org/dozer/vo/enumtest/MyBean.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/enumtest/MyBeanPrime.java
+++ b/core/src/test/java/org/dozer/vo/enumtest/MyBeanPrime.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/enumtest/MyBeanPrimeByte.java
+++ b/core/src/test/java/org/dozer/vo/enumtest/MyBeanPrimeByte.java
@@ -1,5 +1,5 @@
-/*
- * Copyright 2005-2010 the original author or authors.
+/**
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/enumtest/MyBeanPrimeInteger.java
+++ b/core/src/test/java/org/dozer/vo/enumtest/MyBeanPrimeInteger.java
@@ -1,5 +1,5 @@
-/*
- * Copyright 2005-2010 the original author or authors.
+/**
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/enumtest/MyBeanPrimeLong.java
+++ b/core/src/test/java/org/dozer/vo/enumtest/MyBeanPrimeLong.java
@@ -1,5 +1,5 @@
-/*
- * Copyright 2005-2010 the original author or authors.
+/**
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/enumtest/MyBeanPrimeShort.java
+++ b/core/src/test/java/org/dozer/vo/enumtest/MyBeanPrimeShort.java
@@ -1,5 +1,5 @@
-/*
- * Copyright 2005-2010 the original author or authors.
+/**
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/enumtest/MyBeanPrimeString.java
+++ b/core/src/test/java/org/dozer/vo/enumtest/MyBeanPrimeString.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/enumtest/SrcType.java
+++ b/core/src/test/java/org/dozer/vo/enumtest/SrcType.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/enumtest/SrcTypeWithOverride.java
+++ b/core/src/test/java/org/dozer/vo/enumtest/SrcTypeWithOverride.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/excluded/OneA.java
+++ b/core/src/test/java/org/dozer/vo/excluded/OneA.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/excluded/OneB.java
+++ b/core/src/test/java/org/dozer/vo/excluded/OneB.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/excluded/TwoA.java
+++ b/core/src/test/java/org/dozer/vo/excluded/TwoA.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/excluded/TwoB.java
+++ b/core/src/test/java/org/dozer/vo/excluded/TwoB.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/excluded/ZeroA.java
+++ b/core/src/test/java/org/dozer/vo/excluded/ZeroA.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/excluded/ZeroB.java
+++ b/core/src/test/java/org/dozer/vo/excluded/ZeroB.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/generics/Entity.java
+++ b/core/src/test/java/org/dozer/vo/generics/Entity.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/generics/IntEntity.java
+++ b/core/src/test/java/org/dozer/vo/generics/IntEntity.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/generics/Status.java
+++ b/core/src/test/java/org/dozer/vo/generics/Status.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/generics/StatusPrime.java
+++ b/core/src/test/java/org/dozer/vo/generics/StatusPrime.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/generics/User.java
+++ b/core/src/test/java/org/dozer/vo/generics/User.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/generics/UserGroup.java
+++ b/core/src/test/java/org/dozer/vo/generics/UserGroup.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/generics/UserGroupPrime.java
+++ b/core/src/test/java/org/dozer/vo/generics/UserGroupPrime.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/generics/UserPrime.java
+++ b/core/src/test/java/org/dozer/vo/generics/UserPrime.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/generics/deepindex/AnotherTestObject.java
+++ b/core/src/test/java/org/dozer/vo/generics/deepindex/AnotherTestObject.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/generics/deepindex/DestDeepObj.java
+++ b/core/src/test/java/org/dozer/vo/generics/deepindex/DestDeepObj.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/generics/deepindex/Family.java
+++ b/core/src/test/java/org/dozer/vo/generics/deepindex/Family.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/generics/deepindex/HeadOfHouseHold.java
+++ b/core/src/test/java/org/dozer/vo/generics/deepindex/HeadOfHouseHold.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/generics/deepindex/PersonalDetails.java
+++ b/core/src/test/java/org/dozer/vo/generics/deepindex/PersonalDetails.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/generics/deepindex/Pet.java
+++ b/core/src/test/java/org/dozer/vo/generics/deepindex/Pet.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/generics/deepindex/SrcDeepObj.java
+++ b/core/src/test/java/org/dozer/vo/generics/deepindex/SrcDeepObj.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/generics/deepindex/TestObject.java
+++ b/core/src/test/java/org/dozer/vo/generics/deepindex/TestObject.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/generics/deepindex/TestObjectPrime.java
+++ b/core/src/test/java/org/dozer/vo/generics/deepindex/TestObjectPrime.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/generics/parameterized/A.java
+++ b/core/src/test/java/org/dozer/vo/generics/parameterized/A.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/generics/parameterized/AA.java
+++ b/core/src/test/java/org/dozer/vo/generics/parameterized/AA.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/generics/parameterized/AbstractB.java
+++ b/core/src/test/java/org/dozer/vo/generics/parameterized/AbstractB.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/generics/parameterized/AbstractDto.java
+++ b/core/src/test/java/org/dozer/vo/generics/parameterized/AbstractDto.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/generics/parameterized/B.java
+++ b/core/src/test/java/org/dozer/vo/generics/parameterized/B.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/generics/parameterized/C.java
+++ b/core/src/test/java/org/dozer/vo/generics/parameterized/C.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/generics/parameterized/Dto.java
+++ b/core/src/test/java/org/dozer/vo/generics/parameterized/Dto.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/generics/parameterized/GenericTestType.java
+++ b/core/src/test/java/org/dozer/vo/generics/parameterized/GenericTestType.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/generics/parameterized/GenericType.java
+++ b/core/src/test/java/org/dozer/vo/generics/parameterized/GenericType.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/generics/parameterized/TestSimpleGenerics.java
+++ b/core/src/test/java/org/dozer/vo/generics/parameterized/TestSimpleGenerics.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/iface/ApplicationUser.java
+++ b/core/src/test/java/org/dozer/vo/iface/ApplicationUser.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/iface/Subscriber.java
+++ b/core/src/test/java/org/dozer/vo/iface/Subscriber.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/iface/SubscriberIF.java
+++ b/core/src/test/java/org/dozer/vo/iface/SubscriberIF.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/iface/SubscriberKey.java
+++ b/core/src/test/java/org/dozer/vo/iface/SubscriberKey.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/iface/UpdateMember.java
+++ b/core/src/test/java/org/dozer/vo/iface/UpdateMember.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/index/Mccoy.java
+++ b/core/src/test/java/org/dozer/vo/index/Mccoy.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/index/MccoyPrime.java
+++ b/core/src/test/java/org/dozer/vo/index/MccoyPrime.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/inheritance/A.java
+++ b/core/src/test/java/org/dozer/vo/inheritance/A.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/inheritance/AnotherBaseClass.java
+++ b/core/src/test/java/org/dozer/vo/inheritance/AnotherBaseClass.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/inheritance/AnotherBaseClassPrime.java
+++ b/core/src/test/java/org/dozer/vo/inheritance/AnotherBaseClassPrime.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/inheritance/AnotherSubClass.java
+++ b/core/src/test/java/org/dozer/vo/inheritance/AnotherSubClass.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/inheritance/AnotherSubClassPrime.java
+++ b/core/src/test/java/org/dozer/vo/inheritance/AnotherSubClassPrime.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/inheritance/B.java
+++ b/core/src/test/java/org/dozer/vo/inheritance/B.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/inheritance/BaseClass.java
+++ b/core/src/test/java/org/dozer/vo/inheritance/BaseClass.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/inheritance/BaseSubClass.java
+++ b/core/src/test/java/org/dozer/vo/inheritance/BaseSubClass.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/inheritance/BaseSubClassCombined.java
+++ b/core/src/test/java/org/dozer/vo/inheritance/BaseSubClassCombined.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/inheritance/BaseSubClassPrime.java
+++ b/core/src/test/java/org/dozer/vo/inheritance/BaseSubClassPrime.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/inheritance/ChildChildIF.java
+++ b/core/src/test/java/org/dozer/vo/inheritance/ChildChildIF.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/inheritance/ChildIF.java
+++ b/core/src/test/java/org/dozer/vo/inheritance/ChildIF.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/inheritance/GenericAbstractSuper.java
+++ b/core/src/test/java/org/dozer/vo/inheritance/GenericAbstractSuper.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/inheritance/GenericIF.java
+++ b/core/src/test/java/org/dozer/vo/inheritance/GenericIF.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/inheritance/Inner.java
+++ b/core/src/test/java/org/dozer/vo/inheritance/Inner.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/inheritance/IntermediateClass.java
+++ b/core/src/test/java/org/dozer/vo/inheritance/IntermediateClass.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/inheritance/Main.java
+++ b/core/src/test/java/org/dozer/vo/inheritance/Main.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/inheritance/MainDto.java
+++ b/core/src/test/java/org/dozer/vo/inheritance/MainDto.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/inheritance/Outer.java
+++ b/core/src/test/java/org/dozer/vo/inheritance/Outer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/inheritance/ParentIF.java
+++ b/core/src/test/java/org/dozer/vo/inheritance/ParentIF.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/inheritance/S2Class.java
+++ b/core/src/test/java/org/dozer/vo/inheritance/S2Class.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/inheritance/S2ClassPrime.java
+++ b/core/src/test/java/org/dozer/vo/inheritance/S2ClassPrime.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/inheritance/SClass.java
+++ b/core/src/test/java/org/dozer/vo/inheritance/SClass.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/inheritance/SClassPrime.java
+++ b/core/src/test/java/org/dozer/vo/inheritance/SClassPrime.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/inheritance/Specific1.java
+++ b/core/src/test/java/org/dozer/vo/inheritance/Specific1.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/inheritance/Specific2.java
+++ b/core/src/test/java/org/dozer/vo/inheritance/Specific2.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/inheritance/Specific3.java
+++ b/core/src/test/java/org/dozer/vo/inheritance/Specific3.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/inheritance/SpecificObject.java
+++ b/core/src/test/java/org/dozer/vo/inheritance/SpecificObject.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/inheritance/Sub.java
+++ b/core/src/test/java/org/dozer/vo/inheritance/Sub.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/inheritance/SubClass.java
+++ b/core/src/test/java/org/dozer/vo/inheritance/SubClass.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/inheritance/SubDto.java
+++ b/core/src/test/java/org/dozer/vo/inheritance/SubDto.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/inheritance/SubMarker.java
+++ b/core/src/test/java/org/dozer/vo/inheritance/SubMarker.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/inheritance/SubMarkerDto.java
+++ b/core/src/test/java/org/dozer/vo/inheritance/SubMarkerDto.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/inheritance/SuperA.java
+++ b/core/src/test/java/org/dozer/vo/inheritance/SuperA.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/inheritance/SuperB.java
+++ b/core/src/test/java/org/dozer/vo/inheritance/SuperB.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/inheritance/SuperSpecificObject.java
+++ b/core/src/test/java/org/dozer/vo/inheritance/SuperSpecificObject.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/inheritance/Target.java
+++ b/core/src/test/java/org/dozer/vo/inheritance/Target.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/inheritance/WrapperSpecific.java
+++ b/core/src/test/java/org/dozer/vo/inheritance/WrapperSpecific.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/inheritance/WrapperSpecificPrime.java
+++ b/core/src/test/java/org/dozer/vo/inheritance/WrapperSpecificPrime.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/inheritance/cc/A.java
+++ b/core/src/test/java/org/dozer/vo/inheritance/cc/A.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/inheritance/cc/B.java
+++ b/core/src/test/java/org/dozer/vo/inheritance/cc/B.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/inheritance/cc/C.java
+++ b/core/src/test/java/org/dozer/vo/inheritance/cc/C.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/inheritance/cc/InheritanceBugConverter.java
+++ b/core/src/test/java/org/dozer/vo/inheritance/cc/InheritanceBugConverter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/inheritance/cc/X.java
+++ b/core/src/test/java/org/dozer/vo/inheritance/cc/X.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/inheritance/cc/Y.java
+++ b/core/src/test/java/org/dozer/vo/inheritance/cc/Y.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/inheritance/cc/Z.java
+++ b/core/src/test/java/org/dozer/vo/inheritance/cc/Z.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/inheritance/hints/Base.java
+++ b/core/src/test/java/org/dozer/vo/inheritance/hints/Base.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/inheritance/hints/Base2.java
+++ b/core/src/test/java/org/dozer/vo/inheritance/hints/Base2.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/inheritance/hints/BaseA.java
+++ b/core/src/test/java/org/dozer/vo/inheritance/hints/BaseA.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/inheritance/hints/BaseA2.java
+++ b/core/src/test/java/org/dozer/vo/inheritance/hints/BaseA2.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/inheritance/hints/BaseB.java
+++ b/core/src/test/java/org/dozer/vo/inheritance/hints/BaseB.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/inheritance/hints/BaseB2.java
+++ b/core/src/test/java/org/dozer/vo/inheritance/hints/BaseB2.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/inheritance/hints/Source.java
+++ b/core/src/test/java/org/dozer/vo/inheritance/hints/Source.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/inheritance/hints/Target.java
+++ b/core/src/test/java/org/dozer/vo/inheritance/hints/Target.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/inheritance/iface/Person.java
+++ b/core/src/test/java/org/dozer/vo/inheritance/iface/Person.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/inheritance/iface/PersonDTO.java
+++ b/core/src/test/java/org/dozer/vo/inheritance/iface/PersonDTO.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/inheritance/iface/PersonImpl.java
+++ b/core/src/test/java/org/dozer/vo/inheritance/iface/PersonImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/inheritance/iface/PersonProfile.java
+++ b/core/src/test/java/org/dozer/vo/inheritance/iface/PersonProfile.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/inheritance/iface/PersonWithAddressDTO.java
+++ b/core/src/test/java/org/dozer/vo/inheritance/iface/PersonWithAddressDTO.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/inheritance/twolevel/A.java
+++ b/core/src/test/java/org/dozer/vo/inheritance/twolevel/A.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/inheritance/twolevel/B.java
+++ b/core/src/test/java/org/dozer/vo/inheritance/twolevel/B.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/inheritance/twolevel/C.java
+++ b/core/src/test/java/org/dozer/vo/inheritance/twolevel/C.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/interfacerecursion/AnotherLevelTwo.java
+++ b/core/src/test/java/org/dozer/vo/interfacerecursion/AnotherLevelTwo.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/interfacerecursion/AnotherLevelTwoImpl.java
+++ b/core/src/test/java/org/dozer/vo/interfacerecursion/AnotherLevelTwoImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/interfacerecursion/Base.java
+++ b/core/src/test/java/org/dozer/vo/interfacerecursion/Base.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/interfacerecursion/BaseImpl.java
+++ b/core/src/test/java/org/dozer/vo/interfacerecursion/BaseImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/interfacerecursion/LevelOne.java
+++ b/core/src/test/java/org/dozer/vo/interfacerecursion/LevelOne.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/interfacerecursion/LevelOneImpl.java
+++ b/core/src/test/java/org/dozer/vo/interfacerecursion/LevelOneImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/interfacerecursion/LevelTwo.java
+++ b/core/src/test/java/org/dozer/vo/interfacerecursion/LevelTwo.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/interfacerecursion/LevelTwoImpl.java
+++ b/core/src/test/java/org/dozer/vo/interfacerecursion/LevelTwoImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/interfacerecursion/User.java
+++ b/core/src/test/java/org/dozer/vo/interfacerecursion/User.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/interfacerecursion/UserGroup.java
+++ b/core/src/test/java/org/dozer/vo/interfacerecursion/UserGroup.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/interfacerecursion/UserGroupImpl.java
+++ b/core/src/test/java/org/dozer/vo/interfacerecursion/UserGroupImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/interfacerecursion/UserGroupPrime.java
+++ b/core/src/test/java/org/dozer/vo/interfacerecursion/UserGroupPrime.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/interfacerecursion/UserGroupPrimeImpl.java
+++ b/core/src/test/java/org/dozer/vo/interfacerecursion/UserGroupPrimeImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/interfacerecursion/UserImpl.java
+++ b/core/src/test/java/org/dozer/vo/interfacerecursion/UserImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/interfacerecursion/UserPrime.java
+++ b/core/src/test/java/org/dozer/vo/interfacerecursion/UserPrime.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/interfacerecursion/UserPrimeImpl.java
+++ b/core/src/test/java/org/dozer/vo/interfacerecursion/UserPrimeImpl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/interfacerecursion/UserSub.java
+++ b/core/src/test/java/org/dozer/vo/interfacerecursion/UserSub.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/isaccessible/Foo.java
+++ b/core/src/test/java/org/dozer/vo/isaccessible/Foo.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/isaccessible/FooPrime.java
+++ b/core/src/test/java/org/dozer/vo/isaccessible/FooPrime.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/isaccessible/PrivateConstructorBean.java
+++ b/core/src/test/java/org/dozer/vo/isaccessible/PrivateConstructorBean.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/isaccessible/PrivateConstructorBeanPrime.java
+++ b/core/src/test/java/org/dozer/vo/isaccessible/PrivateConstructorBeanPrime.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/km/Property.java
+++ b/core/src/test/java/org/dozer/vo/km/Property.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/km/PropertyB.java
+++ b/core/src/test/java/org/dozer/vo/km/PropertyB.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/km/SomeVo.java
+++ b/core/src/test/java/org/dozer/vo/km/SomeVo.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/km/Sub.java
+++ b/core/src/test/java/org/dozer/vo/km/Sub.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/km/Super.java
+++ b/core/src/test/java/org/dozer/vo/km/Super.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/map/ChildDOM.java
+++ b/core/src/test/java/org/dozer/vo/map/ChildDOM.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/map/CustomMap.java
+++ b/core/src/test/java/org/dozer/vo/map/CustomMap.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/map/CustomMapIF.java
+++ b/core/src/test/java/org/dozer/vo/map/CustomMapIF.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/map/GenericDOM.java
+++ b/core/src/test/java/org/dozer/vo/map/GenericDOM.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/map/House.java
+++ b/core/src/test/java/org/dozer/vo/map/House.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/map/MapTestObject.java
+++ b/core/src/test/java/org/dozer/vo/map/MapTestObject.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/map/MapTestObjectPrime.java
+++ b/core/src/test/java/org/dozer/vo/map/MapTestObjectPrime.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/map/MapToMap.java
+++ b/core/src/test/java/org/dozer/vo/map/MapToMap.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/map/MapToMapPrime.java
+++ b/core/src/test/java/org/dozer/vo/map/MapToMapPrime.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/map/MapToProperty.java
+++ b/core/src/test/java/org/dozer/vo/map/MapToProperty.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/map/NestedObj.java
+++ b/core/src/test/java/org/dozer/vo/map/NestedObj.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/map/NestedObjPrime.java
+++ b/core/src/test/java/org/dozer/vo/map/NestedObjPrime.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/map/ParentDOM.java
+++ b/core/src/test/java/org/dozer/vo/map/ParentDOM.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/map/PropertyToMap.java
+++ b/core/src/test/java/org/dozer/vo/map/PropertyToMap.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/map/Room.java
+++ b/core/src/test/java/org/dozer/vo/map/Room.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/map/SimpleObj.java
+++ b/core/src/test/java/org/dozer/vo/map/SimpleObj.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/map/SimpleObjPrime.java
+++ b/core/src/test/java/org/dozer/vo/map/SimpleObjPrime.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/mapid/AContainer.java
+++ b/core/src/test/java/org/dozer/vo/mapid/AContainer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/mapid/AListContainer.java
+++ b/core/src/test/java/org/dozer/vo/mapid/AListContainer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/mapid/BContainer.java
+++ b/core/src/test/java/org/dozer/vo/mapid/BContainer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/mapid/BContainer2.java
+++ b/core/src/test/java/org/dozer/vo/mapid/BContainer2.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/mapidsameinstance/One.java
+++ b/core/src/test/java/org/dozer/vo/mapidsameinstance/One.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2005-2017 Dozer Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.dozer.vo.mapidsameinstance;
 
 public class One {

--- a/core/src/test/java/org/dozer/vo/mapidsameinstance/Two.java
+++ b/core/src/test/java/org/dozer/vo/mapidsameinstance/Two.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2005-2017 Dozer Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.dozer.vo.mapidsameinstance;
 
 public class Two {

--- a/core/src/test/java/org/dozer/vo/mapperaware/MapperAwareSimpleDest.java
+++ b/core/src/test/java/org/dozer/vo/mapperaware/MapperAwareSimpleDest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/mapperaware/MapperAwareSimpleInternal.java
+++ b/core/src/test/java/org/dozer/vo/mapperaware/MapperAwareSimpleInternal.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/mapperaware/MapperAwareSimpleSrc.java
+++ b/core/src/test/java/org/dozer/vo/mapperaware/MapperAwareSimpleSrc.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/metadata/ClassA.java
+++ b/core/src/test/java/org/dozer/vo/metadata/ClassA.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/metadata/ClassB.java
+++ b/core/src/test/java/org/dozer/vo/metadata/ClassB.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/metadata/ClassC.java
+++ b/core/src/test/java/org/dozer/vo/metadata/ClassC.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/metadata/ClassD.java
+++ b/core/src/test/java/org/dozer/vo/metadata/ClassD.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/oneway/DestClass.java
+++ b/core/src/test/java/org/dozer/vo/oneway/DestClass.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/oneway/Holder.java
+++ b/core/src/test/java/org/dozer/vo/oneway/Holder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/oneway/SourceClass.java
+++ b/core/src/test/java/org/dozer/vo/oneway/SourceClass.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/orphan/Child.java
+++ b/core/src/test/java/org/dozer/vo/orphan/Child.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/orphan/ChildPrime.java
+++ b/core/src/test/java/org/dozer/vo/orphan/ChildPrime.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/orphan/Parent.java
+++ b/core/src/test/java/org/dozer/vo/orphan/Parent.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/orphan/ParentPrime.java
+++ b/core/src/test/java/org/dozer/vo/orphan/ParentPrime.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/perf/MyClassA.java
+++ b/core/src/test/java/org/dozer/vo/perf/MyClassA.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/perf/MyClassB.java
+++ b/core/src/test/java/org/dozer/vo/perf/MyClassB.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/recursive/ClassA.java
+++ b/core/src/test/java/org/dozer/vo/recursive/ClassA.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/recursive/ClassAA.java
+++ b/core/src/test/java/org/dozer/vo/recursive/ClassAA.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/recursive/ClassAAPrime.java
+++ b/core/src/test/java/org/dozer/vo/recursive/ClassAAPrime.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/recursive/ClassAPrime.java
+++ b/core/src/test/java/org/dozer/vo/recursive/ClassAPrime.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/recursive/ClassB.java
+++ b/core/src/test/java/org/dozer/vo/recursive/ClassB.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/recursive/ClassBPrime.java
+++ b/core/src/test/java/org/dozer/vo/recursive/ClassBPrime.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/runtimesubclass/SpecialUserGroup.java
+++ b/core/src/test/java/org/dozer/vo/runtimesubclass/SpecialUserGroup.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/runtimesubclass/SpecialUserGroupPrime.java
+++ b/core/src/test/java/org/dozer/vo/runtimesubclass/SpecialUserGroupPrime.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/runtimesubclass/User.java
+++ b/core/src/test/java/org/dozer/vo/runtimesubclass/User.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/runtimesubclass/UserGroup.java
+++ b/core/src/test/java/org/dozer/vo/runtimesubclass/UserGroup.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/runtimesubclass/UserGroupPrime.java
+++ b/core/src/test/java/org/dozer/vo/runtimesubclass/UserGroupPrime.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/runtimesubclass/UserPrime.java
+++ b/core/src/test/java/org/dozer/vo/runtimesubclass/UserPrime.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/self/Account.java
+++ b/core/src/test/java/org/dozer/vo/self/Account.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/self/Address.java
+++ b/core/src/test/java/org/dozer/vo/self/Address.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/self/SimpleAccount.java
+++ b/core/src/test/java/org/dozer/vo/self/SimpleAccount.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/set/NamesArray.java
+++ b/core/src/test/java/org/dozer/vo/set/NamesArray.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/set/NamesList.java
+++ b/core/src/test/java/org/dozer/vo/set/NamesList.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/set/NamesSet.java
+++ b/core/src/test/java/org/dozer/vo/set/NamesSet.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/set/NamesSortedSet.java
+++ b/core/src/test/java/org/dozer/vo/set/NamesSortedSet.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/set/SomeDTO.java
+++ b/core/src/test/java/org/dozer/vo/set/SomeDTO.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/set/SomeOtherDTO.java
+++ b/core/src/test/java/org/dozer/vo/set/SomeOtherDTO.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/set/SomeOtherVO.java
+++ b/core/src/test/java/org/dozer/vo/set/SomeOtherVO.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/org/dozer/vo/set/SomeVO.java
+++ b/core/src/test/java/org/dozer/vo/set/SomeVO.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/resources/IndividualMapping.xml
+++ b/core/src/test/resources/IndividualMapping.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/resources/abstractMapping.xml
+++ b/core/src/test/resources/abstractMapping.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/resources/abstractMapping2.xml
+++ b/core/src/test/resources/abstractMapping2.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/resources/abstractMapping3.xml
+++ b/core/src/test/resources/abstractMapping3.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/resources/allowedExceptionsMapping.xml
+++ b/core/src/test/resources/allowedExceptionsMapping.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/resources/arrayMapping.xml
+++ b/core/src/test/resources/arrayMapping.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/resources/arrayToStringCustomConverter.xml
+++ b/core/src/test/resources/arrayToStringCustomConverter.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/resources/classLevelIsAccessible.xml
+++ b/core/src/test/resources/classLevelIsAccessible.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/resources/classloader.xml
+++ b/core/src/test/resources/classloader.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/resources/collectionsWithNull.xml
+++ b/core/src/test/resources/collectionsWithNull.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/resources/contextMapping.xml
+++ b/core/src/test/resources/contextMapping.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/resources/copyByReferenceCollectionTest.xml
+++ b/core/src/test/resources/copyByReferenceCollectionTest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/resources/cumulative.xml
+++ b/core/src/test/resources/cumulative.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/resources/custom-converter-map-null.xml
+++ b/core/src/test/resources/custom-converter-map-null.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/resources/customConverterMapperAware.xml
+++ b/core/src/test/resources/customConverterMapperAware.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/resources/customGlobalConfigWithNullAndEmptyStringTest.xml
+++ b/core/src/test/resources/customGlobalConfigWithNullAndEmptyStringTest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/resources/customMappingsLoaderTest.xml
+++ b/core/src/test/resources/customMappingsLoaderTest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/resources/customMappingsLoaderWithGlobalConfigTest.xml
+++ b/core/src/test/resources/customMappingsLoaderWithGlobalConfigTest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/resources/customfactorymapping.xml
+++ b/core/src/test/resources/customfactorymapping.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/resources/dateFormat.xml
+++ b/core/src/test/resources/dateFormat.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/resources/deepMappingUsingCustomGetSet.xml
+++ b/core/src/test/resources/deepMappingUsingCustomGetSet.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/resources/deepMappingWithIndexAndIsAccessible.xml
+++ b/core/src/test/resources/deepMappingWithIndexAndIsAccessible.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/resources/deepMappingWithIndexedFields.xml
+++ b/core/src/test/resources/deepMappingWithIndexedFields.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/resources/deepMappingWithIndexedFieldsByCustomConverter.xml
+++ b/core/src/test/resources/deepMappingWithIndexedFieldsByCustomConverter.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/resources/dozer.properties
+++ b/core/src/test/resources/dozer.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2005-2013 Dozer Project
+# Copyright 2005-2017 Dozer Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/core/src/test/resources/dozerBeanMapping.xml
+++ b/core/src/test/resources/dozerBeanMapping.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/resources/duplicateMapIdsMapping.xml
+++ b/core/src/test/resources/duplicateMapIdsMapping.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/resources/duplicateMapping.xml
+++ b/core/src/test/resources/duplicateMapping.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/resources/emptymapping.xml
+++ b/core/src/test/resources/emptymapping.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/resources/enumMapping.xml
+++ b/core/src/test/resources/enumMapping.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/resources/enumMappingOverriedEnumToBasedEnum.xml
+++ b/core/src/test/resources/enumMappingOverriedEnumToBasedEnum.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/resources/excludedField.xml
+++ b/core/src/test/resources/excludedField.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/resources/fieldAttributeMapping.xml
+++ b/core/src/test/resources/fieldAttributeMapping.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/resources/fieldCustomConverter.xml
+++ b/core/src/test/resources/fieldCustomConverter.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/resources/fieldCustomConverterParam.xml
+++ b/core/src/test/resources/fieldCustomConverterParam.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/resources/genericCollectionMapping.xml
+++ b/core/src/test/resources/genericCollectionMapping.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/resources/global-configuration.xml
+++ b/core/src/test/resources/global-configuration.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/resources/global-mapping.xml
+++ b/core/src/test/resources/global-mapping.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/resources/grandparent.xml
+++ b/core/src/test/resources/grandparent.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/resources/implicitAllowedExceptionsMapping.xml
+++ b/core/src/test/resources/implicitAllowedExceptionsMapping.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/resources/indexMapping.xml
+++ b/core/src/test/resources/indexMapping.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/resources/infiniteLoopMapping.xml
+++ b/core/src/test/resources/infiniteLoopMapping.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/resources/inheritanceBug.xml
+++ b/core/src/test/resources/inheritanceBug.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/resources/inheritanceDirection.xml
+++ b/core/src/test/resources/inheritanceDirection.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/resources/inheritanceHints.xml
+++ b/core/src/test/resources/inheritanceHints.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/resources/inheritanceMapping.xml
+++ b/core/src/test/resources/inheritanceMapping.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/resources/inheritanceMapping2.xml
+++ b/core/src/test/resources/inheritanceMapping2.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/resources/inheritanceMapping3.xml
+++ b/core/src/test/resources/inheritanceMapping3.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/resources/inheritanceMapping4.xml
+++ b/core/src/test/resources/inheritanceMapping4.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/resources/inheritanceMappingMapBacked.xml
+++ b/core/src/test/resources/inheritanceMappingMapBacked.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/resources/inheritanceTwoLevel.xml
+++ b/core/src/test/resources/inheritanceTwoLevel.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/resources/interface-recursion-mappings.xml
+++ b/core/src/test/resources/interface-recursion-mappings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/resources/interfaceMapping.xml
+++ b/core/src/test/resources/interfaceMapping.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/resources/invalidmapping1.xml
+++ b/core/src/test/resources/invalidmapping1.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/resources/invalidmapping2.xml
+++ b/core/src/test/resources/invalidmapping2.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/resources/invalidmapping3.xml
+++ b/core/src/test/resources/invalidmapping3.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/resources/invalidmapping4.xml
+++ b/core/src/test/resources/invalidmapping4.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/resources/invalidmapping5.xml
+++ b/core/src/test/resources/invalidmapping5.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/resources/invalidmappingdtd.xml
+++ b/core/src/test/resources/invalidmappingdtd.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/resources/isaccessiblemapping.xml
+++ b/core/src/test/resources/isaccessiblemapping.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/resources/jaxbBeansMapping.xml
+++ b/core/src/test/resources/jaxbBeansMapping.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/resources/kmmapping.xml
+++ b/core/src/test/resources/kmmapping.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/resources/knownFailures.xml
+++ b/core/src/test/resources/knownFailures.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/resources/listMapping.xml
+++ b/core/src/test/resources/listMapping.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/resources/log4j.properties
+++ b/core/src/test/resources/log4j.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2005-2013 Dozer Project
+# Copyright 2005-2017 Dozer Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/core/src/test/resources/mapBackedDeepMapping.xml
+++ b/core/src/test/resources/mapBackedDeepMapping.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/resources/mapGetSetMethodMapping.xml
+++ b/core/src/test/resources/mapGetSetMethodMapping.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/resources/mapIdWithHint.xml
+++ b/core/src/test/resources/mapIdWithHint.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/resources/mapInterfaceMapping.xml
+++ b/core/src/test/resources/mapInterfaceMapping.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/resources/mapMapping.xml
+++ b/core/src/test/resources/mapMapping.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/resources/mapMapping2.xml
+++ b/core/src/test/resources/mapMapping2.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/resources/mapMapping3.xml
+++ b/core/src/test/resources/mapMapping3.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/resources/mapMapping4.xml
+++ b/core/src/test/resources/mapMapping4.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/resources/mapMapping5.xml
+++ b/core/src/test/resources/mapMapping5.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/resources/mapMapping6.xml
+++ b/core/src/test/resources/mapMapping6.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/resources/mapMapping7.xml
+++ b/core/src/test/resources/mapMapping7.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/resources/mapidsameinstance.xml
+++ b/core/src/test/resources/mapidsameinstance.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2015 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/resources/mapper-aware.xml
+++ b/core/src/test/resources/mapper-aware.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/resources/mapping-concrete.xml
+++ b/core/src/test/resources/mapping-concrete.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/resources/mapping-interface.xml
+++ b/core/src/test/resources/mapping-interface.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/resources/mappingProcessorArrayTest.xml
+++ b/core/src/test/resources/mappingProcessorArrayTest.xml
@@ -1,4 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2005-2017 Dozer Project
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
 <mappings xmlns="http://dozer.sourceforge.net"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://dozer.sourceforge.net

--- a/core/src/test/resources/metadataTest.xml
+++ b/core/src/test/resources/metadataTest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/resources/missingSetter.xml
+++ b/core/src/test/resources/missingSetter.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/resources/multipleHintsMapping.xml
+++ b/core/src/test/resources/multipleHintsMapping.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/resources/nestedAccessible.xml
+++ b/core/src/test/resources/nestedAccessible.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/resources/newCustomConverter.xml
+++ b/core/src/test/resources/newCustomConverter.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/resources/nullFieldMapping.xml
+++ b/core/src/test/resources/nullFieldMapping.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/resources/nullMapping.xml
+++ b/core/src/test/resources/nullMapping.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/resources/oneWayMapping.xml
+++ b/core/src/test/resources/oneWayMapping.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/resources/overridemapping.xml
+++ b/core/src/test/resources/overridemapping.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/resources/primitiveArrayToListMapping.xml
+++ b/core/src/test/resources/primitiveArrayToListMapping.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/resources/recursivemappings.xml
+++ b/core/src/test/resources/recursivemappings.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/resources/recursivemappings2.xml
+++ b/core/src/test/resources/recursivemappings2.xml
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/resources/reference-mapping.xml
+++ b/core/src/test/resources/reference-mapping.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/resources/relationship-type-global-configuration.xml
+++ b/core/src/test/resources/relationship-type-global-configuration.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/resources/relationshipTypeMapping.xml
+++ b/core/src/test/resources/relationshipTypeMapping.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/resources/removeOrphansMapping.xml
+++ b/core/src/test/resources/removeOrphansMapping.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/resources/runtimeSubclass.xml
+++ b/core/src/test/resources/runtimeSubclass.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/resources/samplecustomdozer.properties
+++ b/core/src/test/resources/samplecustomdozer.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2005-2013 Dozer Project
+# Copyright 2005-2017 Dozer Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/core/src/test/resources/selfreference_recursive.xml
+++ b/core/src/test/resources/selfreference_recursive.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/resources/selfreference_recursive_iterate.xml
+++ b/core/src/test/resources/selfreference_recursive_iterate.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/resources/setMappingWithUpperCaseFieldName.xml
+++ b/core/src/test/resources/setMappingWithUpperCaseFieldName.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/resources/simpleCustomConverter.xml
+++ b/core/src/test/resources/simpleCustomConverter.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/resources/superInterfaceMapping.xml
+++ b/core/src/test/resources/superInterfaceMapping.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/resources/systempropertymapping1.xml
+++ b/core/src/test/resources/systempropertymapping1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/resources/systempropertymapping2.xml
+++ b/core/src/test/resources/systempropertymapping2.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/resources/topLevelMapping.xml
+++ b/core/src/test/resources/topLevelMapping.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/resources/trimStringsMapping.xml
+++ b/core/src/test/resources/trimStringsMapping.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/resources/untypedCollection.xml
+++ b/core/src/test/resources/untypedCollection.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/resources/useCustomConverter.xml
+++ b/core/src/test/resources/useCustomConverter.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/resources/variables.xml
+++ b/core/src/test/resources/variables.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/resources/xmlBeansMapping.xml
+++ b/core/src/test/resources/xmlBeansMapping.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/xsd/jaxb/Employee.xsd
+++ b/core/src/test/xsd/jaxb/Employee.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/xsd/xmlbeans/WeatherForecast.xsd
+++ b/core/src/test/xsd/xmlbeans/WeatherForecast.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/core/src/test/xsd/xmlbeans/parentChild.xsd
+++ b/core/src/test/xsd/xmlbeans/parentChild.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/eclipse-plugin/net.sf.dozer.eclipse.feature/build.properties
+++ b/eclipse-plugin/net.sf.dozer.eclipse.feature/build.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2005-2013 Dozer Project
+# Copyright 2005-2017 Dozer Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/eclipse-plugin/net.sf.dozer.eclipse.feature/feature.xml
+++ b/eclipse-plugin/net.sf.dozer.eclipse.feature/feature.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/eclipse-plugin/net.sf.dozer.eclipse.plugin/build.properties
+++ b/eclipse-plugin/net.sf.dozer.eclipse.plugin/build.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2005-2013 Dozer Project
+# Copyright 2005-2017 Dozer Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/eclipse-plugin/net.sf.dozer.eclipse.plugin/plugin.xml
+++ b/eclipse-plugin/net.sf.dozer.eclipse.plugin/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/eclipse-plugin/net.sf.dozer.eclipse.plugin/schema/beanmapping.xsd
+++ b/eclipse-plugin/net.sf.dozer.eclipse.plugin/schema/beanmapping.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/eclipse-plugin/net.sf.dozer.eclipse.plugin/schema/dozerbeanmapping.dtd
+++ b/eclipse-plugin/net.sf.dozer.eclipse.plugin/schema/dozerbeanmapping.dtd
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/eclipse-plugin/net.sf.dozer.eclipse.plugin/src/org/dozer/eclipse/plugin/DozerMultiPageEditor.java
+++ b/eclipse-plugin/net.sf.dozer.eclipse.plugin/src/org/dozer/eclipse/plugin/DozerMultiPageEditor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/eclipse-plugin/net.sf.dozer.eclipse.plugin/src/org/dozer/eclipse/plugin/DozerPlugin.java
+++ b/eclipse-plugin/net.sf.dozer.eclipse.plugin/src/org/dozer/eclipse/plugin/DozerPlugin.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/eclipse-plugin/net.sf.dozer.eclipse.plugin/src/org/dozer/eclipse/plugin/editorpage/DozerFormEditor.java
+++ b/eclipse-plugin/net.sf.dozer.eclipse.plugin/src/org/dozer/eclipse/plugin/editorpage/DozerFormEditor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/eclipse-plugin/net.sf.dozer.eclipse.plugin/src/org/dozer/eclipse/plugin/editorpage/DozerModelManager.java
+++ b/eclipse-plugin/net.sf.dozer.eclipse.plugin/src/org/dozer/eclipse/plugin/editorpage/DozerModelManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/eclipse-plugin/net.sf.dozer.eclipse.plugin/src/org/dozer/eclipse/plugin/editorpage/Messages.java
+++ b/eclipse-plugin/net.sf.dozer.eclipse.plugin/src/org/dozer/eclipse/plugin/editorpage/Messages.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/eclipse-plugin/net.sf.dozer.eclipse.plugin/src/org/dozer/eclipse/plugin/editorpage/actions/CollapseAllAction.java
+++ b/eclipse-plugin/net.sf.dozer.eclipse.plugin/src/org/dozer/eclipse/plugin/editorpage/actions/CollapseAllAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/eclipse-plugin/net.sf.dozer.eclipse.plugin/src/org/dozer/eclipse/plugin/editorpage/actions/PackageExtendAction.java
+++ b/eclipse-plugin/net.sf.dozer.eclipse.plugin/src/org/dozer/eclipse/plugin/editorpage/actions/PackageExtendAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/eclipse-plugin/net.sf.dozer.eclipse.plugin/src/org/dozer/eclipse/plugin/editorpage/imagecombo/ImageCombo.java
+++ b/eclipse-plugin/net.sf.dozer.eclipse.plugin/src/org/dozer/eclipse/plugin/editorpage/imagecombo/ImageCombo.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/eclipse-plugin/net.sf.dozer.eclipse.plugin/src/org/dozer/eclipse/plugin/editorpage/imagecombo/ImageComboViewer.java
+++ b/eclipse-plugin/net.sf.dozer.eclipse.plugin/src/org/dozer/eclipse/plugin/editorpage/imagecombo/ImageComboViewer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/eclipse-plugin/net.sf.dozer.eclipse.plugin/src/org/dozer/eclipse/plugin/editorpage/messages.properties
+++ b/eclipse-plugin/net.sf.dozer.eclipse.plugin/src/org/dozer/eclipse/plugin/editorpage/messages.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2005-2013 Dozer Project
+# Copyright 2005-2017 Dozer Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/eclipse-plugin/net.sf.dozer.eclipse.plugin/src/org/dozer/eclipse/plugin/editorpage/pages/CustomConverterAddDialog.java
+++ b/eclipse-plugin/net.sf.dozer.eclipse.plugin/src/org/dozer/eclipse/plugin/editorpage/pages/CustomConverterAddDialog.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/eclipse-plugin/net.sf.dozer.eclipse.plugin/src/org/dozer/eclipse/plugin/editorpage/pages/DozerConfigurationEditorPage.java
+++ b/eclipse-plugin/net.sf.dozer.eclipse.plugin/src/org/dozer/eclipse/plugin/editorpage/pages/DozerConfigurationEditorPage.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/eclipse-plugin/net.sf.dozer.eclipse.plugin/src/org/dozer/eclipse/plugin/editorpage/pages/DozerMappingEditorPage.java
+++ b/eclipse-plugin/net.sf.dozer.eclipse.plugin/src/org/dozer/eclipse/plugin/editorpage/pages/DozerMappingEditorPage.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/eclipse-plugin/net.sf.dozer.eclipse.plugin/src/org/dozer/eclipse/plugin/editorpage/pages/FieldDetailsPage.java
+++ b/eclipse-plugin/net.sf.dozer.eclipse.plugin/src/org/dozer/eclipse/plugin/editorpage/pages/FieldDetailsPage.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/eclipse-plugin/net.sf.dozer.eclipse.plugin/src/org/dozer/eclipse/plugin/editorpage/pages/MappingDetailsPage.java
+++ b/eclipse-plugin/net.sf.dozer.eclipse.plugin/src/org/dozer/eclipse/plugin/editorpage/pages/MappingDetailsPage.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/eclipse-plugin/net.sf.dozer.eclipse.plugin/src/org/dozer/eclipse/plugin/editorpage/pages/MappingMasterPage.java
+++ b/eclipse-plugin/net.sf.dozer.eclipse.plugin/src/org/dozer/eclipse/plugin/editorpage/pages/MappingMasterPage.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/eclipse-plugin/net.sf.dozer.eclipse.plugin/src/org/dozer/eclipse/plugin/editorpage/pages/composites/AddRemoveListComposite.java
+++ b/eclipse-plugin/net.sf.dozer.eclipse.plugin/src/org/dozer/eclipse/plugin/editorpage/pages/composites/AddRemoveListComposite.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/eclipse-plugin/net.sf.dozer.eclipse.plugin/src/org/dozer/eclipse/plugin/editorpage/pages/composites/ConfigurationOptionComposite.java
+++ b/eclipse-plugin/net.sf.dozer.eclipse.plugin/src/org/dozer/eclipse/plugin/editorpage/pages/composites/ConfigurationOptionComposite.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/eclipse-plugin/net.sf.dozer.eclipse.plugin/src/org/dozer/eclipse/plugin/editorpage/pages/composites/FieldOptionComposite.java
+++ b/eclipse-plugin/net.sf.dozer.eclipse.plugin/src/org/dozer/eclipse/plugin/editorpage/pages/composites/FieldOptionComposite.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/eclipse-plugin/net.sf.dozer.eclipse.plugin/src/org/dozer/eclipse/plugin/editorpage/pages/composites/MappingClassComposite.java
+++ b/eclipse-plugin/net.sf.dozer.eclipse.plugin/src/org/dozer/eclipse/plugin/editorpage/pages/composites/MappingClassComposite.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/eclipse-plugin/net.sf.dozer.eclipse.plugin/src/org/dozer/eclipse/plugin/editorpage/pages/composites/MappingFieldComposite.java
+++ b/eclipse-plugin/net.sf.dozer.eclipse.plugin/src/org/dozer/eclipse/plugin/editorpage/pages/composites/MappingFieldComposite.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/eclipse-plugin/net.sf.dozer.eclipse.plugin/src/org/dozer/eclipse/plugin/editorpage/pages/composites/ObservableSingleSelectionObject.java
+++ b/eclipse-plugin/net.sf.dozer.eclipse.plugin/src/org/dozer/eclipse/plugin/editorpage/pages/composites/ObservableSingleSelectionObject.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/eclipse-plugin/net.sf.dozer.eclipse.plugin/src/org/dozer/eclipse/plugin/editorpage/utils/DOMUtils.java
+++ b/eclipse-plugin/net.sf.dozer.eclipse.plugin/src/org/dozer/eclipse/plugin/editorpage/utils/DOMUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/eclipse-plugin/net.sf.dozer.eclipse.plugin/src/org/dozer/eclipse/plugin/editorpage/utils/DozerUiUtils.java
+++ b/eclipse-plugin/net.sf.dozer.eclipse.plugin/src/org/dozer/eclipse/plugin/editorpage/utils/DozerUiUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/eclipse-plugin/net.sf.dozer.eclipse.plugin/src/org/dozer/eclipse/plugin/editorpage/utils/DozerUtils.java
+++ b/eclipse-plugin/net.sf.dozer.eclipse.plugin/src/org/dozer/eclipse/plugin/editorpage/utils/DozerUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/eclipse-plugin/net.sf.dozer.eclipse.plugin/src/org/dozer/eclipse/plugin/editorpage/utils/ElementAsClassLabelProvider.java
+++ b/eclipse-plugin/net.sf.dozer.eclipse.plugin/src/org/dozer/eclipse/plugin/editorpage/utils/ElementAsClassLabelProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/eclipse-plugin/net.sf.dozer.eclipse.plugin/src/org/dozer/eclipse/plugin/editorpage/utils/HyperlinkHelper.java
+++ b/eclipse-plugin/net.sf.dozer.eclipse.plugin/src/org/dozer/eclipse/plugin/editorpage/utils/HyperlinkHelper.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/eclipse-plugin/net.sf.dozer.eclipse.plugin/src/org/dozer/eclipse/plugin/editorpage/utils/LazyDomContentProvider.java
+++ b/eclipse-plugin/net.sf.dozer.eclipse.plugin/src/org/dozer/eclipse/plugin/editorpage/utils/LazyDomContentProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/eclipse-plugin/net.sf.dozer.eclipse.plugin/src/org/dozer/eclipse/plugin/editorpage/utils/LocatedLazyObserving.java
+++ b/eclipse-plugin/net.sf.dozer.eclipse.plugin/src/org/dozer/eclipse/plugin/editorpage/utils/LocatedLazyObserving.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/eclipse-plugin/net.sf.dozer.eclipse.plugin/src/org/dozer/eclipse/plugin/editorpage/utils/MappingUtils.java
+++ b/eclipse-plugin/net.sf.dozer.eclipse.plugin/src/org/dozer/eclipse/plugin/editorpage/utils/MappingUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/eclipse-plugin/net.sf.dozer.eclipse.plugin/src/org/dozer/eclipse/plugin/editorpage/utils/ObservableUtils.java
+++ b/eclipse-plugin/net.sf.dozer.eclipse.plugin/src/org/dozer/eclipse/plugin/editorpage/utils/ObservableUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/eclipse-plugin/net.sf.dozer.eclipse.plugin/src/org/dozer/eclipse/plugin/editorpage/utils/StringToFieldConverter.java
+++ b/eclipse-plugin/net.sf.dozer.eclipse.plugin/src/org/dozer/eclipse/plugin/editorpage/utils/StringToFieldConverter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/eclipse-plugin/net.sf.dozer.eclipse.plugin/src/org/dozer/eclipse/plugin/editorpage/utils/StringToMethodConverter.java
+++ b/eclipse-plugin/net.sf.dozer.eclipse.plugin/src/org/dozer/eclipse/plugin/editorpage/utils/StringToMethodConverter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/eclipse-plugin/net.sf.dozer.eclipse.plugin/src/org/dozer/eclipse/plugin/editorpage/utils/TableViewerSelectionListener.java
+++ b/eclipse-plugin/net.sf.dozer.eclipse.plugin/src/org/dozer/eclipse/plugin/editorpage/utils/TableViewerSelectionListener.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/eclipse-plugin/net.sf.dozer.eclipse.plugin/src/org/dozer/eclipse/plugin/sourcepage/DozerStructuredTextViewerConfiguration.java
+++ b/eclipse-plugin/net.sf.dozer.eclipse.plugin/src/org/dozer/eclipse/plugin/sourcepage/DozerStructuredTextViewerConfiguration.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/eclipse-plugin/net.sf.dozer.eclipse.plugin/src/org/dozer/eclipse/plugin/sourcepage/contentassist/DozerContentAssistProcessor.java
+++ b/eclipse-plugin/net.sf.dozer.eclipse.plugin/src/org/dozer/eclipse/plugin/sourcepage/contentassist/DozerContentAssistProcessor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/eclipse-plugin/net.sf.dozer.eclipse.plugin/src/org/dozer/eclipse/plugin/sourcepage/contentassist/DozerJavaCompletionProposal.java
+++ b/eclipse-plugin/net.sf.dozer.eclipse.plugin/src/org/dozer/eclipse/plugin/sourcepage/contentassist/DozerJavaCompletionProposal.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/eclipse-plugin/net.sf.dozer.eclipse.plugin/src/org/dozer/eclipse/plugin/sourcepage/hyperlink/DozerClassHyperlinkDetector.java
+++ b/eclipse-plugin/net.sf.dozer.eclipse.plugin/src/org/dozer/eclipse/plugin/sourcepage/hyperlink/DozerClassHyperlinkDetector.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/eclipse-plugin/net.sf.dozer.eclipse.plugin/src/org/dozer/eclipse/plugin/sourcepage/hyperlink/SourceModelHyperlink.java
+++ b/eclipse-plugin/net.sf.dozer.eclipse.plugin/src/org/dozer/eclipse/plugin/sourcepage/hyperlink/SourceModelHyperlink.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/eclipse-plugin/net.sf.dozer.eclipse.plugin/src/org/dozer/eclipse/plugin/sourcepage/util/DozerPluginUtils.java
+++ b/eclipse-plugin/net.sf.dozer.eclipse.plugin/src/org/dozer/eclipse/plugin/sourcepage/util/DozerPluginUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/eclipse-plugin/net.sf.dozer.eclipse.plugin/src/org/dozer/eclipse/plugin/sourcepage/validation/Validator.java
+++ b/eclipse-plugin/net.sf.dozer.eclipse.plugin/src/org/dozer/eclipse/plugin/sourcepage/validation/Validator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/eclipse-plugin/net.sf.dozer.eclipse.plugin/src/org/dozer/eclipse/plugin/wizards/NewMappingConfigFilePage.java
+++ b/eclipse-plugin/net.sf.dozer.eclipse.plugin/src/org/dozer/eclipse/plugin/wizards/NewMappingConfigFilePage.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/eclipse-plugin/net.sf.dozer.eclipse.plugin/src/org/dozer/eclipse/plugin/wizards/NewMappingFileWizard.java
+++ b/eclipse-plugin/net.sf.dozer.eclipse.plugin/src/org/dozer/eclipse/plugin/wizards/NewMappingFileWizard.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/osgi-test/pom.xml
+++ b/osgi-test/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@
   <parent>
     <groupId>net.sf.dozer</groupId>
     <artifactId>dozer-parent</artifactId>
-    <version>5.5.1</version>
+    <version>6.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>dozer-osgi-test</artifactId>

--- a/osgi-test/src/test/java/org/dozer/osgi/OsgiContainerTest.java
+++ b/osgi-test/src/test/java/org/dozer/osgi/OsgiContainerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/osgi-test/src/test/resources/mapping.xml
+++ b/osgi-test/src/test/resources/mapping.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/osgi/pom.xml
+++ b/osgi/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@
   <parent>
     <groupId>net.sf.dozer</groupId>
     <artifactId>dozer-parent</artifactId>
-    <version>5.5.1</version>
+    <version>6.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>dozer-osgi</artifactId>
@@ -136,7 +136,7 @@
     <dependency>
       <groupId>org.apache.felix</groupId>
       <artifactId>org.apache.felix.framework</artifactId>
-      <version>4.0.3</version>
+      <version>4.4.1</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@
   <groupId>net.sf.dozer</groupId>
   <artifactId>dozer-parent</artifactId>
   <packaging>pom</packaging>
-  <version>5.5.1</version>
+  <version>6.0.0-SNAPSHOT</version>
   <url>http://dozer.sourceforge.net</url>
   <name>Dozer Parent Project</name>
   <description>Dozer is a powerful Java Bean to Java Bean mapper that recursively copies data from one object to
@@ -65,15 +65,51 @@
 
   <repositories>
     <repository>
-      <id>java.net</id>
-      <url>http://download.java.net/maven/2</url>
+      <id>snapshots.sonatype.org</id>
+      <name>Sonatype Snapshots</name>
+      <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+    </repository>
+    <repository>
+      <id>releases.sonatype.org</id>
+      <name>Sonatype Releases</name>
+      <url>https://oss.sonatype.org/content/repositories/releases/</url>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
     </repository>
   </repositories>
 
   <pluginRepositories>
     <pluginRepository>
-      <id>snapshots</id>
-      <url>http://snapshots.maven.codehaus.org/maven2</url>
+      <id>snapshots.sonatype.org</id>
+      <name>Sonatype Snapshots</name>
+      <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+    </pluginRepository>
+    <pluginRepository>
+      <id>releases.sonatype.org</id>
+      <name>Sonatype Releases</name>
+      <url>https://oss.sonatype.org/content/repositories/releases/</url>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
     </pluginRepository>
   </pluginRepositories>
 
@@ -390,7 +426,7 @@
     <connection>scm:git:https//github.com/DozerMapper/dozer</connection>
     <developerConnection>scm:git:git@github.com:DozerMapper/dozer.git</developerConnection>
     <url>https://github.com/DozerMapper/Dozer</url>
-    <tag>dozer-5.5.1</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <ciManagement>

--- a/proto/pom.xml
+++ b/proto/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@
   <parent>
     <groupId>net.sf.dozer</groupId>
     <artifactId>dozer-parent</artifactId>
-    <version>5.5.1</version>
+    <version>6.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>dozer-proto</artifactId>

--- a/proto/src/main/java/org/dozer/ProtobufSupportModule.java
+++ b/proto/src/main/java/org/dozer/ProtobufSupportModule.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/proto/src/main/java/org/dozer/builder/ByProtobufBuilder.java
+++ b/proto/src/main/java/org/dozer/builder/ByProtobufBuilder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/proto/src/main/java/org/dozer/builder/ProtoBeanBuilder.java
+++ b/proto/src/main/java/org/dozer/builder/ProtoBeanBuilder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/proto/src/main/java/org/dozer/classmap/generator/ProtobufBeanFieldsDetector.java
+++ b/proto/src/main/java/org/dozer/classmap/generator/ProtobufBeanFieldsDetector.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/proto/src/main/java/org/dozer/propertydescriptor/ProtoFieldPropertyDescriptor.java
+++ b/proto/src/main/java/org/dozer/propertydescriptor/ProtoFieldPropertyDescriptor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/proto/src/main/java/org/dozer/propertydescriptor/ProtoFieldPropertyDescriptorCreationStrategy.java
+++ b/proto/src/main/java/org/dozer/propertydescriptor/ProtoFieldPropertyDescriptorCreationStrategy.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/proto/src/main/java/org/dozer/util/ProtoUtils.java
+++ b/proto/src/main/java/org/dozer/util/ProtoUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/proto/src/main/java/org/dozer/util/ProtoUtils.java
+++ b/proto/src/main/java/org/dozer/util/ProtoUtils.java
@@ -15,12 +15,10 @@
  */
 package org.dozer.util;
 
-import com.google.protobuf.ByteString;
-import com.google.protobuf.Descriptors;
-import com.google.protobuf.Message;
-import com.google.protobuf.ProtocolMessageEnum;
+import com.google.protobuf.*;
 import org.apache.commons.lang3.StringUtils;
 
+import java.lang.Enum;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -100,19 +98,22 @@ public class ProtoUtils {
       //code duplicate, but GenericDescriptor interface is private in protobuf
       case ENUM       : return getEnumClassByEnumDescriptor(descriptor.getEnumType());
       case MESSAGE    :
-        return MappingUtils.loadClass(StringUtils.join(new String[]{
-                descriptor.getMessageType().getFile().getOptions().getJavaPackage(),
-                descriptor.getMessageType().getFile().getOptions().getJavaOuterClassname(),
-                descriptor.getMessageType().getFullName()}, '.'));
+        return MappingUtils.loadClass(StringUtils.join(
+                getFullyQualifiedClassName(descriptor.getMessageType().getFile().getOptions(), descriptor.getMessageType().getName()), '.'));
       default         : throw new RuntimeException();
     }
   }
 
+  private static String[] getFullyQualifiedClassName(DescriptorProtos.FileOptions options, String name) {
+      return new String[]{
+            options.getJavaPackage(),
+            options.getJavaOuterClassname(),
+            name};
+  }
+
   private static Class<? extends Enum> getEnumClassByEnumDescriptor(Descriptors.EnumDescriptor descriptor) {
-    return (Class<? extends Enum>)MappingUtils.loadClass(StringUtils.join(new String[]{
-            descriptor.getFile().getOptions().getJavaPackage(),
-            descriptor.getFile().getOptions().getJavaOuterClassname(),
-            descriptor.getFullName()}, '.'));
+    return (Class<? extends Enum>)MappingUtils.loadClass(StringUtils.join(
+            getFullyQualifiedClassName(descriptor.getFile().getOptions(), descriptor.getName()), '.'));
   }
 
   public static Object wrapEnums(Object value) {

--- a/proto/src/test/java/org/dozer/functional_tests/ProtoAbstractTest.java
+++ b/proto/src/test/java/org/dozer/functional_tests/ProtoAbstractTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/proto/src/test/java/org/dozer/functional_tests/ProtoBeansDeepMappingTest.java
+++ b/proto/src/test/java/org/dozer/functional_tests/ProtoBeansDeepMappingTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/proto/src/test/java/org/dozer/functional_tests/ProtoBeansMappingTest.java
+++ b/proto/src/test/java/org/dozer/functional_tests/ProtoBeansMappingTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/proto/src/test/java/org/dozer/propertydescriptor/ProtoFieldPropertyDescriptorCreationStrategyTest.java
+++ b/proto/src/test/java/org/dozer/propertydescriptor/ProtoFieldPropertyDescriptorCreationStrategyTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/proto/src/test/java/org/dozer/vo/proto/LiteTestObject.java
+++ b/proto/src/test/java/org/dozer/vo/proto/LiteTestObject.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/proto/src/test/java/org/dozer/vo/proto/LiteTestObjectContainer.java
+++ b/proto/src/test/java/org/dozer/vo/proto/LiteTestObjectContainer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/proto/src/test/java/org/dozer/vo/proto/ObjectWithCollection.java
+++ b/proto/src/test/java/org/dozer/vo/proto/ObjectWithCollection.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/proto/src/test/java/org/dozer/vo/proto/ObjectWithEnumCollection.java
+++ b/proto/src/test/java/org/dozer/vo/proto/ObjectWithEnumCollection.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/proto/src/test/java/org/dozer/vo/proto/ObjectWithEnumField.java
+++ b/proto/src/test/java/org/dozer/vo/proto/ObjectWithEnumField.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/proto/src/test/java/org/dozer/vo/proto/ProtoTestObjects.java
+++ b/proto/src/test/java/org/dozer/vo/proto/ProtoTestObjects.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/proto/src/test/java/org/dozer/vo/proto/SimpleEnum.java
+++ b/proto/src/test/java/org/dozer/vo/proto/SimpleEnum.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/proto/src/test/java/org/dozer/vo/proto/TestObject.java
+++ b/proto/src/test/java/org/dozer/vo/proto/TestObject.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/proto/src/test/java/org/dozer/vo/proto/TestObjectContainer.java
+++ b/proto/src/test/java/org/dozer/vo/proto/TestObjectContainer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/proto/src/test/resources/protoBeansMapping.xml
+++ b/proto/src/test/resources/protoBeansMapping.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/proto/src/test/resources/protoSrcDeepBeansMapping.xml
+++ b/proto/src/test/resources/protoSrcDeepBeansMapping.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/spring/pom.xml
+++ b/spring/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@
   <parent>
     <groupId>net.sf.dozer</groupId>
     <artifactId>dozer-parent</artifactId>
-    <version>5.5.1</version>
+    <version>6.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>dozer-spring</artifactId>

--- a/spring/src/main/java/org/dozer/spring/DozerBeanMapperFactoryBean.java
+++ b/spring/src/main/java/org/dozer/spring/DozerBeanMapperFactoryBean.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring/src/main/java/org/dozer/spring/DozerNamespaceHandler.java
+++ b/spring/src/main/java/org/dozer/spring/DozerNamespaceHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring/src/main/java/org/dozer/spring/MapperDefinitionParser.java
+++ b/spring/src/main/java/org/dozer/spring/MapperDefinitionParser.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring/src/main/resources/dozer-spring.xsd
+++ b/spring/src/main/resources/dozer-spring.xsd
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/spring/src/test/java/org/dozer/spring/DozerBeanMapperFactoryBeanTest.java
+++ b/spring/src/test/java/org/dozer/spring/DozerBeanMapperFactoryBeanTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring/src/test/java/org/dozer/spring/functional_tests/NamespaceTest.java
+++ b/spring/src/test/java/org/dozer/spring/functional_tests/NamespaceTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring/src/test/java/org/dozer/spring/functional_tests/SpringIntegrationTest.java
+++ b/spring/src/test/java/org/dozer/spring/functional_tests/SpringIntegrationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring/src/test/java/org/dozer/spring/functional_tests/support/CustomConverterParamConverter.java
+++ b/spring/src/test/java/org/dozer/spring/functional_tests/support/CustomConverterParamConverter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring/src/test/java/org/dozer/spring/functional_tests/support/EventTestListener.java
+++ b/spring/src/test/java/org/dozer/spring/functional_tests/support/EventTestListener.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring/src/test/java/org/dozer/spring/functional_tests/support/InjectedCustomConverter.java
+++ b/spring/src/test/java/org/dozer/spring/functional_tests/support/InjectedCustomConverter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring/src/test/java/org/dozer/spring/functional_tests/support/ReferencingBean.java
+++ b/spring/src/test/java/org/dozer/spring/functional_tests/support/ReferencingBean.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring/src/test/java/org/dozer/spring/functional_tests/support/SampleBeanMappingBuilder.java
+++ b/spring/src/test/java/org/dozer/spring/functional_tests/support/SampleBeanMappingBuilder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring/src/test/java/org/dozer/spring/functional_tests/support/SampleCustomBeanFactory.java
+++ b/spring/src/test/java/org/dozer/spring/functional_tests/support/SampleCustomBeanFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring/src/test/java/org/dozer/spring/vo/Destination.java
+++ b/spring/src/test/java/org/dozer/spring/vo/Destination.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring/src/test/java/org/dozer/spring/vo/Source.java
+++ b/spring/src/test/java/org/dozer/spring/vo/Source.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2005-2013 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring/src/test/resources/applicationContext.xml
+++ b/spring/src/test/resources/applicationContext.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/spring/src/test/resources/mappingSpring.xml
+++ b/spring/src/test/resources/mappingSpring.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/spring/src/test/resources/spring-bean-factory.xml
+++ b/spring/src/test/resources/spring-bean-factory.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/spring/src/test/resources/spring-bean-mapping-builder.xml
+++ b/spring/src/test/resources/spring-bean-mapping-builder.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/spring/src/test/resources/spring-custom-converter.xml
+++ b/spring/src/test/resources/spring-custom-converter.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/spring/src/test/resources/spring-event-listener.xml
+++ b/spring/src/test/resources/spring-event-listener.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/spring/src/test/resources/springNameSpace.xml
+++ b/spring/src/test/resources/springNameSpace.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2013 Dozer Project
+    Copyright 2005-2017 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.


### PR DESCRIPTION
When multiple hints are given to convert custom objects inside a map, primitive types like String were no longer converted because their destFieldType was set to null.
