### PR TITLE
index and releasenotes now use only ISO 8601

### DIFF
--- a/core/src/main/java/org/dozer/factory/XMLBeanFactory.java
+++ b/core/src/main/java/org/dozer/factory/XMLBeanFactory.java
@@ -23,15 +23,15 @@ import java.lang.reflect.Method;
 
 
 /**
- * Public custom bean factory that can be used by applition code when mapping XMLBean data objects
- * 
+ * Public custom bean factory that can be used by application code when mapping XMLBean data objects
+ *
  * @author garsombke.franz
  */
 public class XMLBeanFactory implements BeanFactory {
-  private static final Class<?>[] emptyArglist = new Class[0];
+  private static final Class<?>[] emptyArgList = new Class[0];
   /**
    * Creat a bean implementation of a xml bean interface.
-   * 
+   *
    * @param srcObj
    *          The source object
    * @param srcObjClass
@@ -55,11 +55,11 @@ public class XMLBeanFactory implements BeanFactory {
     }
     Method newInstanceMethod = null;
     try {
-      newInstanceMethod = ReflectionUtils.getMethod(factory, "newInstance", emptyArglist);
+      newInstanceMethod = ReflectionUtils.getMethod(factory, "newInstance", emptyArgList);
     } catch (NoSuchMethodException e) {
       MappingUtils.throwMappingException(e);
     }
-    result = ReflectionUtils.invoke(newInstanceMethod, null, emptyArglist);
+    result = ReflectionUtils.invoke(newInstanceMethod, null, emptyArgList);
     return result;
   }
 }

--- a/core/src/site/xdoc/index.xml
+++ b/core/src/site/xdoc/index.xml
@@ -50,14 +50,14 @@
     <section name="Dozer News">
       <p/>
 
-      <h3>Dozer 5.5.1 is out <font size="-3" color="gray"> <i>22/04/2014</i></font></h3>
+      <h3>Dozer 5.5.1 is out <font size="-3" color="gray"> <i>2014-04-22</i></font></h3>
       <p>
         Release 5.5.1 is available for download and should appear in Maven Central shortly.
         Project has migrated to bintray for hosting binary releases and as an alternative repository location.
         Check release notes for the list of issues closed.
       </p>
 
-      <h3>Dozer 5.4.0 is out <font size="-3" color="gray"> <i>12/01/2012</i></font></h3>
+      <h3>Dozer 5.4.0 is out <font size="-3" color="gray"> <i>2012-12-01</i></font></h3>
       <p>
         Release 5.4.0 is available for download. This is the first release after moving project to GitHub and already
         few new contributors have joined.
@@ -69,7 +69,7 @@
         Old SourceForge Forums and Issue tracker will not be active anymore. They will be disabled once migration is finished.
       </p>
 
-      <h3>Dozer is on GitHub<font size="-3" color="gray"> <i>06/28/2012</i></font></h3>
+      <h3>Dozer is on GitHub<font size="-3" color="gray"> <i>2012-06-28</i></font></h3>
         <p>
             After some inactivity period Dozer has finally moved to
             <a href="https://github.com/DozerMapper/dozer/">GitHub</a>.
@@ -85,7 +85,7 @@
         </p>
         <p/>
 
-        <h3>Release 5.3.2 Now Available<font size="-3" color="gray"> <i>02/15/2011</i></font></h3>
+        <h3>Release 5.3.2 Now Available<font size="-3" color="gray"> <i>2011-02-15</i></font></h3>
         <p>
           Release 5.3.2 is available for download. This is maintenance release, which finalizes internal builder API
           implementation and delivers several bugfixes. Experimental annotations support for simple mappings has been
@@ -99,18 +99,18 @@
         </p>
         <p/>
 
-        <h3>Release 5.3.1 Now Available<font size="-3" color="gray"> <i>11/15/2010</i></font></h3>
+        <h3>Release 5.3.1 Now Available<font size="-3" color="gray"> <i>2010-11-15</i></font></h3>
         <p>
             Release 5.3.1 is available for download. This is maintenance release bringing compatibility with
             Apache Camel framework and fixing a few bugs found in 5.3.0.
             Upgrade is highly recommended for 5.3.0 users.
         </p>
 
-        <h3>Release 5.3.0 Now Available<font size="-3" color="gray"> <i>10/10/2010</i></font></h3>
+        <h3>Release 5.3.0 Now Available<font size="-3" color="gray"> <i>2010-10-10</i></font></h3>
         <p>
             Release 5.3.0 is available for download. This release brings several major changes to Dozer.
             First is migration to SLF4J logging framework. Second is introduction of alternative way of
-            providing custom mappings via Java API. In the meanwhile we reached 50000 downloads 
+            providing custom mappings via Java API. In the meanwhile we reached 50000 downloads
             from the website. This is excluding Maven repository.
         </p>
         <p>
@@ -118,7 +118,7 @@
         </p>
         <p/>
 
-        <h3>Release 5.2.2 Now Available<font size="-3" color="gray"> <i>6/9/2010</i></font></h3>
+        <h3>Release 5.2.2 Now Available<font size="-3" color="gray"> <i>2010-06-09</i></font></h3>
         <p>
             Release 5.2.2 is available for download. This is a maintenance release fixing
             several issues.
@@ -131,7 +131,7 @@
         <p/>
 
 
-      <h3>Release 5.2.1 Now Available<font size="-3" color="gray"> <i>4/28/2010</i></font></h3>
+      <h3>Release 5.2.1 Now Available<font size="-3" color="gray"> <i>2010-04-28</i></font></h3>
       <p>
           Release 5.2.1 is available for download. Important new features are Dozer OSGi bundle and
           Expression Language support. Several bugs has been fixed as well.
@@ -143,7 +143,7 @@
       </p>
       <p/>
 
-      <h3>Release 5.2.0 Now Available<font size="-3" color="gray"> <i>1/24/2010</i></font></h3>
+      <h3>Release 5.2.0 Now Available<font size="-3" color="gray"> <i>2010-01-24</i></font></h3>
       <p>
           Dozer team is happy to announce release 5.2.0. This version fixes fourteen bugs of different kind
           and provides several new features, such as referencing current mapper object inside a custom converter.
@@ -158,7 +158,7 @@
       <h3>
         Release 5.1 Now Available
         <font size="-3" color="gray">
-          <i>8/25/2009</i>
+          <i>2009-08-25</i>
         </font>
       </h3>
       <p>
@@ -176,7 +176,7 @@
       <h3>
         Dozer Eclipse Plugin 0.8.0 Now Available
         <font size="-3" color="gray">
-          <i>6/24/2009</i>
+          <i>2009-06-24</i>
         </font>
       </h3>
       <p>
@@ -208,7 +208,7 @@
       <h3>
         Release 5.0 Now Available
         <font size="-3" color="gray">
-          <i>3/3/2009</i>
+          <i>2009-03-03</i>
         </font>
       </h3>
       <p>
@@ -241,7 +241,7 @@
       <h3>
         Release 4.4.1 Now Available
         <font size="-3" color="gray">
-          <i>1/31/2009</i>
+          <i>2009-01-31</i>
         </font>
       </h3>
       <p>This release fixes classloading issues for custom ClassLoaders. These classloading issues were introduced in
@@ -256,7 +256,7 @@
       <h3>
         Release 4.4 Now Available
         <font size="-3" color="gray">
-          <i>12/27/2008</i>
+          <i>2008-12-27</i>
         </font>
       </h3>
       <p>This release contains various bug fixes and feature requests.</p>
@@ -273,7 +273,7 @@
       <h3>
         Release 4.3 Now Available
         <font size="-3" color="gray">
-          <i>12/03/2008</i>
+          <i>2008-12-03</i>
         </font>
       </h3>
       <p>
@@ -297,7 +297,7 @@
       <h3>
         Release 4.2.1 Now Available
         <font size="-3" color="gray">
-          <i>6/22/2008</i>
+          <i>2008-06-22</i>
         </font>
       </h3>
       <p>This minor release contains a fix for the stop-on-error bug.</p>
@@ -310,7 +310,7 @@
       <h3>
         Release 4.2 Now Available
         <font size="-3" color="gray">
-          <i>12/16/2007</i>
+          <i>2007-12-16</i>
         </font>
       </h3>
       <p>This release contains various bug fixes.</p>
@@ -326,7 +326,7 @@
       <h3>
         Release 4.1 Now Available
         <font size="-3" color="gray">
-          <i>09/22/2007</i>
+          <i>2007-09-22</i>
         </font>
       </h3>
       <p>This release contains bug fixes and feature requests, along with internal refactoring.</p>
@@ -343,7 +343,7 @@
       <h3>
         Release 4.0 Now Available
         <font size="-3" color="gray">
-          <i>07/15/2007</i>
+          <i>2007-07-15</i>
         </font>
       </h3>
       <p>
@@ -373,7 +373,7 @@
       <h3>
         Dozer hits 10,000 Downloads
         <font size="-3" color="gray">
-          <i>05/19/2007</i>
+          <i>2007-05-19</i>
         </font>
       </h3>
       <p>
@@ -384,7 +384,7 @@
       <h3>
         Release 3.4 Now Available
         <font size="-3" color="gray">
-          <i>05/19/2007</i>
+          <i>2007-05-19</i>
         </font>
       </h3>
       <p>This release contains bug fixes and feature requests.</p>
@@ -397,7 +397,7 @@
       <h3>
         Release 3.3.1 Now Available
         <font size="-3" color="gray">
-          <i>04/28/2007</i>
+          <i>2007-04-28</i>
         </font>
       </h3>
       <p>
@@ -412,7 +412,7 @@
       <h3>
         1,000,000 Project Web Hits
         <font size="-3" color="gray">
-          <i>04/08/2007</i>
+          <i>2007-04-08</i>
         </font>
       </h3>
       <p>The Dozer project recently eclipsed the 1 million hit mark. Thanks everyone! It's been fun.</p>
@@ -420,7 +420,7 @@
       <h3>
         Release 3.2.1 Now Available
         <font size="-3" color="gray">
-          <i>04/08/2007</i>
+          <i>2007-04-08</i>
         </font>
       </h3>
       <p>
@@ -435,7 +435,7 @@
       <h3>
         Release 3.2 Now Available
         <font size="-3" color="gray">
-          <i>04/03/2007</i>
+          <i>2007-04-03</i>
         </font>
       </h3>
       <p>This minor release contains bug fixes and feature requests.</p>
@@ -449,7 +449,7 @@
       <h3>
         Release 3.1 Now Available
         <i>
-          <font size="-2" color="gray">03/25/2007</font>
+          <font size="-2" color="gray">2007-03-25</font>
         </i>
       </h3>
       <p>
@@ -471,7 +471,7 @@
       <h3>
         Release 3.0 Now Available
         <i>
-          <font size="-2" color="gray">02/09/2007</font>
+          <font size="-2" color="gray">2007-02-09</font>
         </i>
       </h3>
       <p>
@@ -498,7 +498,7 @@
       <h3>
         Release 2.4 Now Available
         <i>
-          <font size="-2" color="gray">10/16/2006</font>
+          <font size="-2" color="gray">2006-10-16</font>
         </i>
       </h3>
       <p>
@@ -515,7 +515,7 @@
       <h3>
         Release 2.3 Now Available
         <i>
-          <font size="-2" color="gray">09/01/2006</font>
+          <font size="-2" color="gray">2006-09-01</font>
         </i>
       </h3>
       <p>
@@ -532,7 +532,7 @@
       <h3>
         Release 2.2 Now Available
         <i>
-          <font size="-2" color="gray">04/29/2006</font>
+          <font size="-2" color="gray">2006-04-29</font>
         </i>
       </h3>
       <p>
@@ -548,7 +548,7 @@
       <h3>
         Release 2.1 Now Available
         <i>
-          <font size="-2" color="gray">04/18/2006</font>
+          <font size="-2" color="gray">2006-04-18</font>
         </i>
       </h3>
       <p>
@@ -564,7 +564,7 @@
       <h3>
         Release 2.0.1 Now Available
         <i>
-          <font size="-2" color="gray">02/02/2006</font>
+          <font size="-2" color="gray">2006-02-02</font>
         </i>
       </h3>
       <p>This release had a few new features and a few bug fixes.</p>
@@ -576,7 +576,7 @@
       <h3>
         Release 2.0 Now Available
         <i>
-          <font size="-2" color="gray">01/16/2006</font>
+          <font size="-2" color="gray">2006-01-16</font>
         </i>
       </h3>
       <p>
@@ -593,7 +593,7 @@
       <h3>
         Release 1.5.8 Now Available
         <i>
-          <font size="-2" color="gray">11/30/2005</font>
+          <font size="-2" color="gray">2005-11-30</font>
         </i>
       </h3>
       <p>Removed dependency on Castor. We also added a few more features.</p>
@@ -605,7 +605,7 @@
       <h3>
         Release 1.5.7 Now Available
         <i>
-          <font size="-2" color="gray">11/15/2005</font>
+          <font size="-2" color="gray">2005-11-15</font>
         </i>
       </h3>
       <p>
@@ -620,7 +620,7 @@
       <h3>
         Release 1.5.6 Now Available
         <i>
-          <font size="-2" color="gray">10/31/2005</font>
+          <font size="-2" color="gray">2005-10-31</font>
         </i>
       </h3>
       <p>
@@ -631,7 +631,7 @@
       <h3>
         Dozer in the Java Developer's Journal!
         <i>
-          <font size="-2" color="gray">10/15/2005</font>
+          <font size="-2" color="gray">2005-10-15</font>
         </i>
       </h3>
       <p>

--- a/core/src/site/xdoc/releasenotes.xml
+++ b/core/src/site/xdoc/releasenotes.xml
@@ -32,10 +32,10 @@
 
       <section name="Release Notes">
 
-        <h3>5.5.1 <font size="-3" color="gray"><i>22/04/2014</i></font></h3>
+        <h3>5.5.1 <font size="-3" color="gray"><i>2014-04-22</i></font></h3>
         <p><a href="https://github.com/DozerMapper/dozer/issues?milestone=3&amp;state=closed">Release Notes on GitHub</a></p>
 
-        <h3>5.4.0 <font size="-3" color="gray"><i>12/01/2012</i></font></h3>
+        <h3>5.4.0 <font size="-3" color="gray"><i>2012-12-01</i></font></h3>
         <p>Bug Fixes</p>
 
         <ul>
@@ -58,7 +58,7 @@
           <li>Load mappings via InputStream <a href="https://github.com/DozerMapper/dozer/pull/2">link</a></li>
         </ul>
 
-<h3>5.3.2 <font size="-3" color="gray"><i>02/15/2011</i></font></h3>
+<h3>5.3.2 <font size="-3" color="gray"><i>2011-02-15</i></font></h3>
 <p>Bug Fixes</p>
 
 <ul>
@@ -81,7 +81,7 @@
 </ul>
 
 
-<h3>5.3.1 <font size="-3" color="gray"><i>11/15/2010</i></font></h3>
+<h3>5.3.1 <font size="-3" color="gray"><i>2010-11-15</i></font></h3>
 <p>Bug Fixes</p>
 
 <ul>
@@ -95,7 +95,7 @@
 <li>Apache Camel Integration Improvement <a href="https://sourceforge.net/tracker/?func=detail&amp;aid=3022810&amp;group_id=133517&amp;atid=727371">link</a></li>
 </ul>
 
-<h3>5.3.0 <font size="-3" color="gray"><i>10/10/2010</i></font></h3>
+<h3>5.3.0 <font size="-3" color="gray"><i>2010-10-10</i></font></h3>
 <p>Bug Fixes</p>
 
 <ul>
@@ -125,7 +125,7 @@
 </ul>
 
 
-<h3>5.2.2 <font size="-3" color="gray"><i>6/9/2010</i></font></h3>
+<h3>5.2.2 <font size="-3" color="gray"><i>2010-06-09</i></font></h3>
 <p>Bug Fixes</p>
 
 <ul>
@@ -146,7 +146,7 @@
 <li>Improve debug logging <a href="https://sourceforge.net/tracker/?func=detail&amp;aid=2999898&amp;group_id=133517&amp;atid=727371">link</a></li>
 </ul>
 
-          <h3>5.2.1 <font size="-3" color="gray"><i>4/28/2010</i></font></h3>
+          <h3>5.2.1 <font size="-3" color="gray"><i>2010-04-28</i></font></h3>
           <p>Bug Fixes</p>
             <ul>
               <li>Forgotten Custom Converter Parameter in Map-backed Mappings
@@ -177,7 +177,7 @@
             </ul>
 
 
-      <h3>5.2.0 <font size="-3" color="gray"><i>1/24/2010</i></font></h3>
+      <h3>5.2.0 <font size="-3" color="gray"><i>2010-01-24</i></font></h3>
       <p>Bug Fixes</p>
         <ul>
           <li>Failing Top Level Mapping (this -> this)
@@ -231,7 +231,7 @@
           </li>
         </ul>
 
-      <h3>5.1 <font size="-3" color="gray"><i>8/25/2009</i></font></h3>
+      <h3>5.1 <font size="-3" color="gray"><i>2009-08-25</i></font></h3>
       <p>Bug Fixes</p>
         <ul>
           <li>JAXBBeanFactory can not create bean for nested type
@@ -284,7 +284,7 @@
 
       <h3>5.0
         <font size="-3" color="gray">
-          <i>3/3/2009</i>
+          <i>2009-03-03</i>
         </font>
       </h3>
       <p>Migration Guide</p>
@@ -465,7 +465,7 @@
 
       <h3>4.4.1
         <font size="-3" color="gray">
-          <i>1/31/2009</i>
+          <i>2009-01-31</i>
         </font>
       </h3>
       <p>Bug Fixes</p>
@@ -479,7 +479,7 @@
 
       <h3>4.4
         <font size="-3" color="gray">
-          <i>12/27/2008</i>
+          <i>2008-12-27</i>
         </font>
       </h3>
       <p>Bug Fixes and Patches</p>
@@ -555,7 +555,7 @@
         </ul>
       <h3>4.3
         <font size="-3" color="gray">
-          <i>12/03/2008</i>
+          <i>2008-12-03</i>
         </font>
       </h3>
       <p>Bug Fixes</p>
@@ -651,7 +651,7 @@
         </ul>
       <h3>4.2.1
         <font size="-3" color="gray">
-          <i>6/22/2008</i>
+          <i>2008-06-22</i>
         </font>
       </h3>
       <p>Bug Fixes</p>
@@ -665,7 +665,7 @@
 
       <h3>4.2
         <font size="-3" color="gray">
-          <i>12/16/2007</i>
+          <i>2007-12-16</i>
         </font>
       </h3>
       <p>Bug Fixes</p>
@@ -718,7 +718,7 @@
         </ul>
       <h3>4.1
         <font size="-3" color="gray">
-          <i>09/22/2007</i>
+          <i>2007-09-22</i>
         </font>
       </h3>
       <p>Bug Fixes</p>
@@ -799,7 +799,7 @@
         </ul>
       <h3>4.0
         <font size="-3" color="gray">
-          <i>07/15/2007</i>
+          <i>2007-07-15</i>
         </font>
       </h3>
       <p>Bug Fixes</p>
@@ -911,7 +911,7 @@
 
       <h3>3.4
         <font size="-3" color="gray">
-          <i>05/19/2007</i>
+          <i>2007-05-19</i>
         </font>
       </h3>
       <p>Bug Fixes</p>
@@ -993,7 +993,7 @@
 
       <h3>3.3.1
         <font size="-3" color="gray">
-          <i>04/28/2007</i>
+          <i>2007-04-28</i>
         </font>
       </h3>
       <p>Bug Fixes</p>
@@ -1007,7 +1007,7 @@
 
       <h3>3.3
         <font size="-3" color="gray">
-          <i>04/26/2007</i>
+          <i>2007-04-26</i>
         </font>
       </h3>
       <p>Bug Fixes</p>
@@ -1064,12 +1064,12 @@
 
       <h3>3.2.1
         <font size="-3" color="gray">
-          <i>04/08/2007</i>
+          <i>2007-04-08</i>
         </font>
       </h3>
       <p>Feature Requests</p>
         <ul>
-          <li>Boolean to number auto converstion
+          <li>Boolean to number auto conversion
             <a href="http://sourceforge.net/tracker/index.php?func=detail&amp;aid=1695408&amp;group_id=133517&amp;atid=727371">
               1695408
             </a>
@@ -1088,7 +1088,7 @@
 
       <h3>3.2
         <font size="-3" color="gray">
-          <i>04/03/2007</i>
+          <i>2007-04-03</i>
         </font>
       </h3>
       <p>Bug Fixes</p>
@@ -1154,7 +1154,7 @@
         </ul>
       <h3>3.1
         <font size="-3" color="gray">
-          <i>03/25/2007</i>
+          <i>2007-03-25</i>
         </font>
       </h3>
       <p>Patches</p>
@@ -1198,7 +1198,7 @@
         </ul>
       <h3>3.0
         <font size="-3" color="gray">
-          <i>02/08/2007</i>
+          <i>2007-02-08</i>
         </font>
       </h3>
       <p>Bug Fixes</p>
@@ -1295,7 +1295,7 @@
 
       <h3>2.4
         <font size="-3" color="gray">
-          <i>10/14/2006</i>
+          <i>2006-10-14</i>
         </font>
       </h3>
       <p>Bug Fixes</p>
@@ -1356,7 +1356,7 @@
         </ul>
       <h3>2.3
         <font size="-3" color="gray">
-          <i>09/01/2006</i>
+          <i>2006-09-01</i>
         </font>
       </h3>
       <p>Bug Fixes</p>
@@ -1462,7 +1462,7 @@
         </ul>
       <h3>2.2
         <font size="-3" color="gray">
-          <i>04/29/2006</i>
+          <i>2006-04-29</i>
         </font>
       </h3>
         <ul>
@@ -1534,7 +1534,7 @@
         </ul>
       <h3>2.1.1
         <font size="-3" color="gray">
-          <i>04/18/2006</i>
+          <i>2006-04-18</i>
         </font>
       </h3>
         <ul>
@@ -1542,7 +1542,7 @@
         </ul>
       <h3>2.1
         <font size="-3" color="gray">
-          <i>03/15/2006</i>
+          <i>2006-03-15</i>
         </font>
       </h3>
         <ul>
@@ -1585,7 +1585,7 @@
         </ul>
       <h3>2.0.2
         <font size="-3" color="gray">
-          <i>02/29/2006</i>
+          <i>2006-02-29</i>
         </font>
       </h3>
         <ul>
@@ -1603,7 +1603,7 @@
         </ul>
       <h3>2.0.1
         <font size="-3" color="gray">
-          <i>02/02/2006</i>
+          <i>2006-02-02</i>
         </font>
       </h3>
         <ul>
@@ -1641,7 +1641,7 @@
         </ul>
       <h3>2.0
         <font size="-3" color="gray">
-          <i>01/16/2006</i>
+          <i>2006-01-16</i>
         </font>
       </h3>
         <ul>
@@ -1693,7 +1693,7 @@
         </ul>
       <h3>1.5.8.1
         <font size="-3" color="gray">
-          <i>12/08/2005</i>
+          <i>2005-12-08</i>
         </font>
       </h3>
         <ul>
@@ -1743,7 +1743,7 @@
         </ul>
       <h3>1.5.8
         <font size="-3" color="gray">
-          <i>11/29/2005</i>
+          <i>2005-11-29</i>
         </font>
       </h3>
         <ul>
@@ -1785,7 +1785,7 @@
         </ul>
       <h3>1.5.7
         <font size="-3" color="gray">
-          <i>11/15/2005</i>
+          <i>2005-11-15</i>
         </font>
       </h3>
         <ul>
@@ -1839,7 +1839,7 @@
         </ul>
       <h3>1.5.6
         <font size="-3" color="gray">
-          <i>10/30/2005</i>
+          <i>2005-10-30</i>
         </font>
       </h3>
         <ul>
@@ -1891,7 +1891,7 @@
         </ul>
       <h3>1.5.5
         <font size="-3" color="gray">
-          <i>10/13/2005</i>
+          <i>2005-10-13</i>
         </font>
       </h3>
         <ul>
@@ -1927,7 +1927,7 @@
         </ul>
       <h3>1.5.4
         <font size="-3" color="gray">
-          <i>09/20/2005</i>
+          <i>2005-09-20</i>
         </font>
       </h3>
         <ul>
@@ -1942,7 +1942,7 @@
         </ul>
       <h3>1.5.3
         <font size="-3" color="gray">
-          <i>09/16/2005</i>
+          <i>2005-09-16</i>
         </font>
       </h3>
         <ul>
@@ -1957,19 +1957,19 @@
         </ul>
       <h3>1.5.2
         <font size="-3" color="gray">
-          <i>09/14/2005</i>
+          <i>2005-09-14</i>
         </font>
       </h3>
         <ul>
           <li>Added support for multiple source and destination hints in Collection and Array mapping</li>
-          <li>Fixed Mapping iheritance
+          <li>Fixed Mapping inheritance
             <a href="http://sourceforge.net/forum/forum.php?thread_id=1340715&amp;forum_id=452530">issue(s)</a>
           </li>
           <li>Iterate type methods can now return an Iterator for their get() method.</li>
         </ul>
       <h3>1.5.1
         <font size="-3" color="gray">
-          <i>09/07/2005</i>
+          <i>2005-09-07</i>
         </font>
       </h3>
         <ul>
@@ -1984,7 +1984,7 @@
         </ul>
       <h3>1.5.0.1
         <font size="-3" color="gray">
-          <i>08/31/2005</i>
+          <i>2005-08-31</i>
         </font>
       </h3>
         <ul>
@@ -1994,7 +1994,7 @@
         </ul>
       <h3>1.5.0
         <font size="-3" color="gray">
-          <i>08/30/2005</i>
+          <i>2005-08-30</i>
         </font>
       </h3>
         <ul>
@@ -2012,7 +2012,7 @@
         </ul>
       <h3>1.4.6
         <font size="-3" color="gray">
-          <i>08/19/2005</i>
+          <i>2005-08-19</i>
         </font>
       </h3>
         <ul>
@@ -2034,7 +2034,7 @@
         </ul>
       <h3>1.4.5
         <font size="-3" color="gray">
-          <i>08/18/2005</i>
+          <i>2005-08-18</i>
         </font>
       </h3>
         <ul>
@@ -2050,7 +2050,7 @@
         </ul>
       <h3>1.4.4
         <font size="-3" color="gray">
-          <i>08/16/2005</i>
+          <i>2005-08-16</i>
         </font>
       </h3>
         <ul>
@@ -2062,7 +2062,7 @@
         </ul>
       <h3>1.4.3
         <font size="-3" color="gray">
-          <i>08/15/2005</i>
+          <i>2005-08-15</i>
         </font>
       </h3>
         <ul>
@@ -2081,7 +2081,7 @@
         </ul>
       <h3>1.4.2
         <font size="-3" color="gray">
-          <i>08/10/2005</i>
+          <i>2005-08-10</i>
         </font>
       </h3>
         <ul>
@@ -2089,7 +2089,7 @@
         </ul>
       <h3>1.4.1
         <font size="-3" color="gray">
-          <i>07/28/2005</i>
+          <i>2005-07-28</i>
         </font>
       </h3>
         <ul>
@@ -2098,7 +2098,7 @@
         </ul>
       <h3>1.4
         <font size="-3" color="gray">
-          <i>07/11/2005</i>
+          <i>2005-07-11</i>
         </font>
       </h3>
         <ul>
@@ -2111,7 +2111,7 @@
         </ul>
       <h3>1.3.3
         <font size="-3" color="gray">
-          <i>06/07/2005</i>
+          <i>2005-06-07</i>
         </font>
       </h3>
         <ul>
@@ -2120,7 +2120,7 @@
         </ul>
       <h3>1.3.2
         <font size="-3" color="gray">
-          <i>06/03/2005</i>
+          <i>2005-06-03</i>
         </font>
       </h3>
         <ul>
@@ -2129,7 +2129,7 @@
         </ul>
       <h3>1.3.1
         <font size="-3" color="gray">
-          <i>06/02/2005</i>
+          <i>2005-06-02</i>
         </font>
       </h3>
         <ul>
@@ -2139,7 +2139,7 @@
         </ul>
       <h3>1.3
         <font size="-3" color="gray">
-          <i>06/01/2005</i>
+          <i>2005-06-01</i>
         </font>
       </h3>
         <ul>
@@ -2164,7 +2164,7 @@
         </ul>
       <h3>1.2
         <font size="-3" color="gray">
-          <i>05/03/2005</i>
+          <i>2005-05-03</i>
         </font>
       </h3>
         <ul>
@@ -2184,7 +2184,7 @@
         </ul>
       <h3>1.1
         <font size="-3" color="gray">
-          <i>04/06/2005</i>
+          <i>2005-04-06</i>
         </font>
       </h3>
         <ul>


### PR DESCRIPTION
Currently on http://dozer.sourceforge.net/ says that 5.5.1 is out 22/04/2014 and 5.3.2 Now Available 02/15/2011. The dates uses different formats. Please use [ISO 8601](https://xkcd.com/1179/) universally: this is technical documentation so there need not be any exceptions. There were a few dates that I couldn't determine so I had to assume the format was MM/dd/yyyy they were 5.2.2 and every version before 1.4.

I did not change any functionality nor any examples or tests. This would be a patch assuming Semantic versioning but I didn't change any pom since I don't know anything about how you release.