### PR TITLE
Replacing Aether with assembly link resolver to use maven reactor resolution

### DIFF
--- a/bom-dependencies/pom.xml
+++ b/bom-dependencies/pom.xml
@@ -49,7 +49,6 @@
         <junit.version>4.12</junit.version>
         <mockito-all.version>1.10.19</mockito-all.version>
         <pax-exam.version>4.10.0</pax-exam.version>
-        <pax-url-aether.version>1.5.2</pax-url-aether.version>
         <protobuf-java.version>2.6.1</protobuf-java.version>
         <relaxngDatatype.version>20020414</relaxngDatatype.version>
         <osgi.version>6.0.0</osgi.version>
@@ -166,13 +165,8 @@
             </dependency>
             <dependency>
                 <groupId>org.ops4j.pax.exam</groupId>
-                <artifactId>pax-exam-link-mvn</artifactId>
+                <artifactId>pax-exam-link-assembly</artifactId>
                 <version>${pax-exam.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.ops4j.pax.url</groupId>
-                <artifactId>pax-url-aether</artifactId>
-                <version>${pax-url-aether.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.google.protobuf</groupId>

--- a/osgi-test/pom.xml
+++ b/osgi-test/pom.xml
@@ -59,12 +59,7 @@
         </dependency>
         <dependency>
             <groupId>org.ops4j.pax.exam</groupId>
-            <artifactId>pax-exam-link-mvn</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.ops4j.pax.url</groupId>
-            <artifactId>pax-url-aether</artifactId>
+            <artifactId>pax-exam-link-assembly</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -76,6 +71,24 @@
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>com.github.veithen.alta</groupId>
+                <artifactId>alta-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>generate-test-resources</goal>
+                        </goals>
+                        <configuration>
+                            <name>%bundle.symbolicName%.link</name>
+                            <value>%url%</value>
+                            <dependencySet>
+                                <scope>test</scope>
+                            </dependencySet>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.servicemix.tooling</groupId>
                 <artifactId>depends-maven-plugin</artifactId>

--- a/osgi-test/src/test/java/org/dozer/osgi/OsgiContainerTest.java
+++ b/osgi-test/src/test/java/org/dozer/osgi/OsgiContainerTest.java
@@ -17,9 +17,7 @@ package org.dozer.osgi;
 
 import java.util.Collections;
 import java.util.List;
-
 import javax.inject.Inject;
-
 import org.dozer.DozerBeanMapper;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -34,10 +32,9 @@ import org.osgi.framework.BundleContext;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.Assert.assertThat;
 import static org.ops4j.pax.exam.CoreOptions.junitBundles;
-import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
 import static org.ops4j.pax.exam.CoreOptions.options;
 import static org.ops4j.pax.exam.CoreOptions.systemPackages;
-import static org.ops4j.pax.exam.MavenUtils.asInProject;
+import static org.ops4j.pax.exam.CoreOptions.url;
 
 /**
  * @author Dmitry Buzdin
@@ -53,10 +50,10 @@ public class OsgiContainerTest {
   public Option[] config() {
 
     return options(
-        mavenBundle().groupId("net.sf.dozer").artifactId("dozer").version(asInProject()),
-        mavenBundle().groupId("commons-beanutils").artifactId("commons-beanutils").version(asInProject()),
-        mavenBundle().groupId("commons-collections").artifactId("commons-collections").version("3.2.1"),
-        mavenBundle().groupId("org.apache.commons").artifactId("commons-lang3").version(asInProject()),
+        url("link:classpath:net.sf.dozer.dozer.link"),
+        url("link:classpath:org.apache.commons.beanutils.link"),
+        url("link:classpath:org.apache.commons.collections.link"),
+        url("link:classpath:org.apache.commons.lang3.link"),
         junitBundles(),
         systemPackages("javax.net.ssl", "javax.xml.parsers", "javax.management", "javax.xml.datatype",
                        "org.w3c.dom", "org.xml.sax", "org.xml.sax.helpers")

--- a/plugins-parent/pom.xml
+++ b/plugins-parent/pom.xml
@@ -36,6 +36,7 @@
         <bom-dependencies-version>6.0.0-SNAPSHOT</bom-dependencies-version>
 
         <!-- Maven Plugins versions; alphabetical order -->
+        <alta-maven-plugin.version>0.5</alta-maven-plugin.version>
         <maven-checkstyle-plugin.version>2.17</maven-checkstyle-plugin.version>
         <maven-compiler-plugin.version>3.6.1</maven-compiler-plugin.version>
         <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
@@ -108,6 +109,11 @@
         <pluginManagement>
             <plugins>
                 <!-- Maven Plugins; alphabetical order -->
+                <plugin>
+                    <groupId>com.github.veithen.alta</groupId>
+                    <artifactId>alta-maven-plugin</artifactId>
+                    <version>${alta-maven-plugin.version}</version>
+                </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-checkstyle-plugin</artifactId>


### PR DESCRIPTION
Aether resolver used in OSGi tests has some significant drawbacks, where the main one is that it is not using Maven reactor configuration but its own implementation of artifacts resolution. As a result, `mvn package` on clean system will not work: OSGi tests will fail as there are no yet snapshot artifacts in local maven repo. As resolution of dependencies is different, it may also happen that those used for compilation by Maven will be different from provided to OSGi container for test. For other cases and more details please see http://veithen.github.io/alta/examples/pax-exam.html.

This pull request suggests to replace Aether resolver with alternative one which uses Maven reactor to resolve dependencies. 

Part of changes in #336.
