### PR TITLE
Added validation check when resolving XSD

### DIFF
--- a/core/src/main/java/org/dozer/loader/xml/DozerResolver.java
+++ b/core/src/main/java/org/dozer/loader/xml/DozerResolver.java
@@ -52,7 +52,12 @@ public class DozerResolver implements EntityResolver {
         log.debug("Trying to resolve XML entity with public ID [{}] and system ID [{}]", publicId, systemId);
 
         if (VERSION_5_XSD.equalsIgnoreCase(systemId)) {
-            throw new MappingException("Found v5 XSD: '" + VERSION_5_XSD + "'. Expected v6 XSD: '" + VERSION_6_XSD + "'");
+            throw new MappingException("Dozer >= v6.0.0 uses a new XSD location. Your current config needs to be upgraded. "
+                                       + "Found v5 XSD: '"
+                                       + VERSION_5_XSD
+                                       + "'. Expected v6 XSD: '"
+                                       + VERSION_6_XSD
+                                       + "'. Please see migration guide @ https://dozermapper.github.io/gitbook");
         }
 
         try {

--- a/core/src/main/java/org/dozer/loader/xml/DozerResolver.java
+++ b/core/src/main/java/org/dozer/loader/xml/DozerResolver.java
@@ -23,6 +23,7 @@ import java.net.URL;
 import org.xml.sax.EntityResolver;
 import org.xml.sax.InputSource;
 
+import org.dozer.MappingException;
 import org.dozer.config.BeanContainer;
 import org.dozer.schema.DefaultSchemaResolver;
 import org.dozer.schema.SchemaResolver;
@@ -42,11 +43,17 @@ import org.slf4j.LoggerFactory;
 public class DozerResolver implements EntityResolver {
 
     private final Logger log = LoggerFactory.getLogger(DozerResolver.class);
+    private static final String VERSION_5_XSD = "http://dozer.sourceforge.net/schema/beanmapping.xsd";
+    private static final String VERSION_6_XSD = "http://dozermapper.github.io/schema/bean-mapping.xsd";
 
     public InputSource resolveEntity(String publicId, String systemId) {
         InputSource source = null;
 
         log.debug("Trying to resolve XML entity with public ID [{}] and system ID [{}]", publicId, systemId);
+
+        if (VERSION_5_XSD.equalsIgnoreCase(systemId)) {
+            throw new MappingException("Found v5 XSD: '" + VERSION_5_XSD + "'. Expected v6 XSD: '" + VERSION_6_XSD + "'");
+        }
 
         try {
             source = resolveFromClassPath(publicId, systemId);

--- a/core/src/test/java/org/dozer/Version5XSDTest.java
+++ b/core/src/test/java/org/dozer/Version5XSDTest.java
@@ -27,9 +27,15 @@ public class Version5XSDTest {
     @Rule
     public ExpectedException testOldXSDNaming = ExpectedException.none();
 
+    private String message = "Dozer >= v6.0.0 uses a new XSD location. " +
+                             "Your current config needs to be upgraded. " +
+                             "Found v5 XSD: 'http://dozer.sourceforge.net/schema/beanmapping.xsd'. " +
+                             "Expected v6 XSD: 'http://dozermapper.github.io/schema/bean-mapping.xsd'. " +
+                             "Please see migration guide @ https://dozermapper.github.io/gitbook";
+
     @Test
     public void testOldXSDNaming() {
-        testOldXSDNaming.expectMessage(Matchers.containsString("Found v5 XSD: 'http://dozer.sourceforge.net/schema/beanmapping.xsd'. Expected v6 XSD: 'http://dozermapper.github.io/schema/bean-mapping.xsd'"));
+        testOldXSDNaming.expectMessage(Matchers.containsString(message));
         testOldXSDNaming.expect(MappingException.class);
 
         DozerBeanMapper mapper = new DozerBeanMapper(Arrays.asList("non-strict/v5-xsd.xml"));

--- a/core/src/test/java/org/dozer/Version5XSDTest.java
+++ b/core/src/test/java/org/dozer/Version5XSDTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2005-2017 Dozer Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dozer;
+
+import java.util.Arrays;
+
+import org.hamcrest.Matchers;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class Version5XSDTest {
+
+    @Rule
+    public ExpectedException testOldXSDNaming = ExpectedException.none();
+
+    @Test
+    public void testOldXSDNaming() {
+        testOldXSDNaming.expectMessage(Matchers.containsString("Found v5 XSD: 'http://dozer.sourceforge.net/schema/beanmapping.xsd'. Expected v6 XSD: 'http://dozermapper.github.io/schema/bean-mapping.xsd'"));
+        testOldXSDNaming.expect(MappingException.class);
+
+        DozerBeanMapper mapper = new DozerBeanMapper(Arrays.asList("non-strict/v5-xsd.xml"));
+        mapper.getMappingMetadata();
+    }
+}

--- a/core/src/test/resources/non-strict/v5-xsd.xml
+++ b/core/src/test/resources/non-strict/v5-xsd.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2005-2017 Dozer Project
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<mappings xmlns="http://dozer.sourceforge.net"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://dozer.sourceforge.net http://dozer.sourceforge.net/schema/beanmapping.xsd">
+
+</mappings>


### PR DESCRIPTION
This is to force users to move to the v6 XSD, as we can control that where as the old sourceforge is out of our control.