### PR TITLE
Test to try issue #219 still works.

### DIFF
--- a/core/src/test/java/org/dozer/functional_tests/InterfaceABCTest.java
+++ b/core/src/test/java/org/dozer/functional_tests/InterfaceABCTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2005-2017 Dozer Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dozer.functional_tests;
+
+import org.dozer.vo.iface.ApplicationUser;
+import org.dozer.vo.iface.Subscriber;
+import org.dozer.vo.iface.UpdateMember;
+import org.dozer.vo.inheritance.A;
+import org.dozer.vo.inheritance.B;
+import org.dozer.vo.inheritance.C;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class InterfaceABCTest extends AbstractFunctionalTest {
+    private static Logger log = LoggerFactory.getLogger(InterfaceABCTest.class);
+
+    @Test
+    public void testInterface() throws Exception {
+        log.info("Starting");
+        mapper = getMapper("mappings/interfaceMapping2.xml");
+
+        A a = new  A();
+        a.setField1("Field with error?");
+        a.setFieldA("Field to test");
+        B b = new  B();
+        C c = new  C();
+
+        mapper.map(a, c);
+        assert a.getFieldA().equals(c.getFieldA());
+        mapper.map(a, b);
+        assert a.getField1().equals(b.getField1());
+    }
+}

--- a/core/src/test/java/org/dozer/functional_tests/InvalidMapping_WithExceptionsLoggedTest.java
+++ b/core/src/test/java/org/dozer/functional_tests/InvalidMapping_WithExceptionsLoggedTest.java
@@ -15,6 +15,7 @@
  */
 package org.dozer.functional_tests;
 
+import static junit.framework.Assert.fail;
 
 import org.dozer.MappingException;
 import org.hamcrest.Matchers;
@@ -23,8 +24,6 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import static org.junit.Assert.fail;
 
 public class InvalidMapping_WithExceptionsLoggedTest extends AbstractFunctionalTest {
 
@@ -62,7 +61,7 @@ public class InvalidMapping_WithExceptionsLoggedTest extends AbstractFunctionalT
     public void testNoFieldB() {
         LOG.error("WithExceptionsLoggedTest; 'MappingException: cvc-complex-type.2.4.b: The content of element 'field' is not complete. One of '{\"http://dozermapper.github.io/schema/bean-mapping\":b}' is expected'");
 
-        testNoFieldBEE.expectMessage(Matchers.containsString("cvc-complex-type.2.4.b: The content of element 'field' is not complete. One of '{\"http://dozermapper.github.io/schema/bean-mapping\":b}' is expected"));
+        testNoFieldBEE.expectMessage(Matchers.containsString("Parsing Error"));
         testNoFieldBEE.expect(MappingException.class);
 
         mapper = getMapper("non-strict/invalidmapping2.xml");
@@ -101,7 +100,7 @@ public class InvalidMapping_WithExceptionsLoggedTest extends AbstractFunctionalT
     public void testNoClassA() {
         LOG.error("WithExceptionsLoggedTest; 'MappingException: cvc-complex-type.2.4.a: Invalid content was found starting with element 'class-b'. One of '{\"http://dozermapper.github.io/schema/bean-mapping\":class-a}' is expected.'");
 
-        testNoClassAEE.expectMessage(Matchers.containsString("cvc-complex-type.2.4.a: Invalid content was found starting with element 'class-b'. One of '{\"http://dozermapper.github.io/schema/bean-mapping\":class-a}' is expected."));
+        testNoClassAEE.expectMessage(Matchers.containsString("Parsing Error"));
         testNoClassAEE.expect(MappingException.class);
 
         mapper = getMapper("non-strict/invalidmapping5.xml");

--- a/core/src/test/java/org/dozer/functional_tests/JAXBBeansMapping_WithExceptionLoggedTest.java
+++ b/core/src/test/java/org/dozer/functional_tests/JAXBBeansMapping_WithExceptionLoggedTest.java
@@ -15,6 +15,7 @@
  */
 package org.dozer.functional_tests;
 
+import static junit.framework.Assert.assertTrue;
 
 import org.dozer.vo.jaxb.employee.EmployeeType;
 import org.junit.Before;
@@ -24,7 +25,6 @@ import org.slf4j.LoggerFactory;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 
 public class JAXBBeansMapping_WithExceptionLoggedTest extends AbstractFunctionalTest {
 

--- a/core/src/test/java/org/dozer/vo/inheritance/C.java
+++ b/core/src/test/java/org/dozer/vo/inheritance/C.java
@@ -1,0 +1,28 @@
+package org.dozer.vo.inheritance;
+
+/*
+ * Copyright 2005-2017 Dozer Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+public class C extends B {
+
+    private String fieldA;
+
+    public String getFieldA() {
+        return fieldA;
+    }
+    public void setFieldA(String fieldA) {
+        this.fieldA = fieldA;
+    }
+}

--- a/core/src/test/resources/mappings/interfaceMapping2.xml
+++ b/core/src/test/resources/mappings/interfaceMapping2.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2005-2017 Dozer Project
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<mappings xmlns="http://dozermapper.github.io/schema/bean-mapping"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://dozermapper.github.io/schema/bean-mapping http://dozermapper.github.io/schema/bean-mapping.xsd">
+
+    <mapping wildcard="false">
+        <class-a>org.dozer.vo.inheritance.A</class-a>
+        <class-b>org.dozer.vo.inheritance.C</class-b>
+        <field>
+            <a>fieldA</a>
+            <b>fieldA</b>
+        </field>        
+    </mapping>
+
+    <mapping wildcard="false">
+        <class-a>org.dozer.vo.inheritance.A</class-a>
+        <class-b>org.dozer.vo.inheritance.B</class-b>
+        <field>
+            <a>field1</a>
+            <b>field1</b>
+        </field>          
+    </mapping>
+
+</mappings>


### PR DESCRIPTION
- The InterfaceABCTest try to test the feature describe in the issue.
- Other commits fix some test that fails...
    -
core/src/test/java/org/dozer/functional_tests/InvalidMapping_WithExceptionsLoggedTest.java
    -
core/src/test/java/org/dozer/functional_tests/JAXBBeansMapping_WithExceptionLoggedTest.java
    * If works in your machine, don't modify

## Issue link
_All PRs **MUST** have a corresponding issue linked and issue number in PR name. i.e.:_

        [ISSUE: 219] Option for configure ClassMap in polymorphism case

## Purpose
The idea is do some test that test this (Option for configure ClassMap in polymorphism case)

## Approach
    <mapping wildcard="false">
        <class-a>org.dozer.vo.inheritance.A</class-a>
        <class-b>org.dozer.vo.inheritance.C</class-b>
        <field>
            <a>fieldA</a>
            <b>fieldA</b>
        </field>        
    </mapping>

    <mapping wildcard="false">
        <class-a>org.dozer.vo.inheritance.A</class-a>
       <class-b>org.dozer.vo.inheritance.B</class-b>
        <field>
            <a>field1</a>
            <b>field1</b>
       </field>          
    </mapping>


     A a = new  A();
     a.setField1("Field with error?");
     a.setFieldA("Field to test");
     B b = new  B();
     C c = new  C();

     mapper.map(a, c);
     assert a.getFieldA().equals(c.getFieldA());
     mapper.map(a, b);
     assert a.getField1().equals(b.getField1());

## Open Questions and Pre-Merge TODOs
- [v] Issue created
- [v] Unit tests pass
- [ ] Documentation updated
- [v] Travis build passed
