### PR TITLE
Release for 6.1.0

### DIFF
--- a/bom-dependencies/pom.xml
+++ b/bom-dependencies/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.github.dozermapper</groupId>
         <artifactId>dozer-parent</artifactId>
-        <version>6.1.0-SNAPSHOT</version>
+        <version>6.1.0</version>
         <relativePath>../</relativePath>
     </parent>
 

--- a/building-tools/pom.xml
+++ b/building-tools/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.github.dozermapper</groupId>
         <artifactId>dozer-parent</artifactId>
-        <version>6.1.0-SNAPSHOT</version>
+        <version>6.1.0</version>
     </parent>
     <artifactId>building-tools</artifactId>
     <packaging>jar</packaging>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.github.dozermapper</groupId>
         <artifactId>dozer-plugins-parent</artifactId>
-        <version>6.1.0-SNAPSHOT</version>
+        <version>6.1.0</version>
         <relativePath>../plugins-parent</relativePath>
     </parent>
 

--- a/core/src/main/java/org/dozer/util/DozerConstants.java
+++ b/core/src/main/java/org/dozer/util/DozerConstants.java
@@ -33,7 +33,7 @@ public final class DozerConstants {
 
   private DozerConstants() {}
 
-  public static final String CURRENT_VERSION = "6.1.0-SNAPSHOT";
+  public static final String CURRENT_VERSION = "6.1.0";
 
   public static final boolean DEFAULT_WILDCARD_POLICY = true;
   public static final boolean DEFAULT_ERROR_POLICY = true;

--- a/docs/asciidoc/documentation/gettingstarted.adoc
+++ b/docs/asciidoc/documentation/gettingstarted.adoc
@@ -1,4 +1,4 @@
-:dozer-version: 6.1.0-SNAPSHOT
+:dozer-version: 6.1.0
 
 == Getting Started
 === Downloading the Distribution

--- a/jmh-tests/pom.xml
+++ b/jmh-tests/pom.xml
@@ -52,13 +52,13 @@
     <parent>
         <groupId>com.github.dozermapper</groupId>
         <artifactId>dozer-plugins-parent</artifactId>
-        <version>6.1.0-SNAPSHOT</version>
+        <version>6.1.0</version>
         <relativePath>../plugins-parent</relativePath>
     </parent>
 
     <groupId>com.github.dozermapper</groupId>
     <artifactId>dozer-jmh-tests</artifactId>
-    <version>6.1.0-SNAPSHOT</version>
+    <version>6.1.0</version>
     <packaging>jar</packaging>
     <name>Dozer :: JMH Tests</name>
 
@@ -70,7 +70,7 @@
         <dependency>
             <groupId>com.github.dozermapper</groupId>
             <artifactId>dozer-core</artifactId>
-            <version>6.1.0-SNAPSHOT</version>
+            <version>6.1.0</version>
         </dependency>
 
         <!-- JMH -->

--- a/osgi-test/pom.xml
+++ b/osgi-test/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.github.dozermapper</groupId>
         <artifactId>dozer-plugins-parent</artifactId>
-        <version>6.1.0-SNAPSHOT</version>
+        <version>6.1.0</version>
         <relativePath>../plugins-parent</relativePath>
     </parent>
 

--- a/osgi-tests-model/pom.xml
+++ b/osgi-tests-model/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.github.dozermapper</groupId>
         <artifactId>dozer-plugins-parent</artifactId>
-        <version>6.1.0-SNAPSHOT</version>
+        <version>6.1.0</version>
         <relativePath>../plugins-parent</relativePath>
     </parent>
 

--- a/plugins-parent/pom.xml
+++ b/plugins-parent/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.github.dozermapper</groupId>
         <artifactId>dozer-parent</artifactId>
-        <version>6.1.0-SNAPSHOT</version>
+        <version>6.1.0</version>
         <relativePath>../</relativePath>
     </parent>
 
@@ -33,7 +33,7 @@
     <name>Dozer :: Plugins Parent</name>
 
     <properties>
-        <bom-dependencies-version>6.1.0-SNAPSHOT</bom-dependencies-version>
+        <bom-dependencies-version>6.1.0</bom-dependencies-version>
 
         <!-- Maven Plugins versions; alphabetical order -->
         <alta-maven-plugin.version>0.5</alta-maven-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <groupId>com.github.dozermapper</groupId>
     <artifactId>dozer-parent</artifactId>
     <packaging>pom</packaging>
-    <version>6.1.0-SNAPSHOT</version>
+    <version>6.1.0</version>
     <name>Dozer :: Parent</name>
     <description>Dozer is a powerful Java Bean to Java Bean mapper that recursively copies data from one object to another</description>
 
@@ -102,7 +102,7 @@
         <nexus-staging-maven-plugin.version>1.6.7</nexus-staging-maven-plugin.version>
         <versions-maven-plugin.version>2.3</versions-maven-plugin.version>
 
-        <building-tools.version>6.1.0-SNAPSHOT</building-tools.version>
+        <building-tools.version>6.1.0</building-tools.version>
     </properties>
 
     <build>

--- a/proto/pom.xml
+++ b/proto/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.github.dozermapper</groupId>
         <artifactId>dozer-plugins-parent</artifactId>
-        <version>6.1.0-SNAPSHOT</version>
+        <version>6.1.0</version>
         <relativePath>../plugins-parent</relativePath>
     </parent>
 

--- a/schema/pom.xml
+++ b/schema/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.github.dozermapper</groupId>
         <artifactId>dozer-plugins-parent</artifactId>
-        <version>6.1.0-SNAPSHOT</version>
+        <version>6.1.0</version>
         <relativePath>../plugins-parent</relativePath>
     </parent>
     <artifactId>dozer-schema</artifactId>

--- a/spring/pom.xml
+++ b/spring/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.github.dozermapper</groupId>
         <artifactId>dozer-plugins-parent</artifactId>
-        <version>6.1.0-SNAPSHOT</version>
+        <version>6.1.0</version>
         <relativePath>../plugins-parent</relativePath>
     </parent>
 


### PR DESCRIPTION
Thanks to:
@garethahealy
@orange-buffalo 
@jbq 
@STRiDGE 

- [ISSUE 410] Updated spring package to be com.github.dozermapper.spring (#450)
- [ISSUE 410] Updated osgi tests package to be com.github.dozermapper.osgitests (#448)
- [ISSUE 410] Updated proto package to be com.github.dozermapper.protobuf (#447)
- Updated OSGi tests to include an actual mapping (#430)
- Added GitHub issue and pr template (#446)
- Deprecated jmx and stats (#445)
- Added draft 1 of jhm (#431)
- Fix #206 Convert protobuf field names to camel case (#416)
- deprecating additional methods on DozerBeanMapper (most importantly those which change mapper state) in order to completely move to Mapper only usage in future releases (#435)
- Banishing the singletons (#403)
- dozer-proto improvements (#411)
- Do not force get and put methods when using Map (#163)
- Updated Spring xsd to reference gh-pages (#423)
- Updated Core XSD to point to github.io (#414)
- Added new 'customConverterId' function with parameter (#418)
- Added dozer-schema jar (#409)
- Removed site content as this is now asciidoc (#408)