### PR TITLE
Moved code that initMappings to builder

### DIFF
--- a/core/src/test/java/org/dozer/functional_tests/ExceptionHandlingFunctionalTest.java
+++ b/core/src/test/java/org/dozer/functional_tests/ExceptionHandlingFunctionalTest.java
@@ -19,7 +19,6 @@ import org.dozer.DozerBeanMapperBuilder;
 import org.dozer.Mapper;
 import org.dozer.MappingException;
 import org.dozer.loader.api.BeanMappingBuilder;
-import org.junit.Before;
 import org.junit.Test;
 
 /**
@@ -27,14 +26,9 @@ import org.junit.Test;
  */
 public class ExceptionHandlingFunctionalTest extends AbstractFunctionalTest {
 
-  @Override
-  @Before
-  public void setUp() throws Exception {
-    mapper = getMapper("mappings/missingSetter.xml");
-  }
-
   @Test(expected = MappingException.class)
   public void test_UnableToDetermineType() {
+    Mapper mapper = getMapper("mappings/missingSetter.xml");
     mapper.map("", NoNothing.class);
   }
 

--- a/core/src/test/resources/non-strict/classloader.xml
+++ b/core/src/test/resources/non-strict/classloader.xml
@@ -29,8 +29,4 @@
         </custom-converters>
     </configuration>
 
-    <mapping>
-        <class-a></class-a>
-    </mapping>
-
 </mappings>

--- a/spring/src/test/java/com/github/dozermapper/spring/DozerBeanMapperFactoryBeanTest.java
+++ b/spring/src/test/java/com/github/dozermapper/spring/DozerBeanMapperFactoryBeanTest.java
@@ -90,13 +90,9 @@ public class DozerBeanMapperFactoryBeanTest {
         HashMap<String, DozerEventListener> eventListenerMap = new HashMap<String, DozerEventListener>();
         eventListenerMap.put("a", mock(DozerEventListener.class));
 
-        HashMap<String, BeanMappingBuilder> mappingBuilders = new HashMap<String, BeanMappingBuilder>();
-        mappingBuilders.put("a", mock(BeanMappingBuilder.class));
-
         when(mockContext.getBeansOfType(CustomConverter.class)).thenReturn(converterHashMap);
         when(mockContext.getBeansOfType(BeanFactory.class)).thenReturn(beanFactoryMap);
         when(mockContext.getBeansOfType(DozerEventListener.class)).thenReturn(eventListenerMap);
-        when(mockContext.getBeansOfType(BeanMappingBuilder.class)).thenReturn(mappingBuilders);
 
         factory.afterPropertiesSet();
 


### PR DESCRIPTION
As the mapper becomes more immutable and solely about doing the mapping of bean to bean, i've moved the initMappings outside to the builder.

CC @orange-buffalo