### PR TITLE
#495: set classloader to beanContainer

### DIFF
--- a/core/src/main/java/org/dozer/DozerBeanMapperBuilder.java
+++ b/core/src/main/java/org/dozer/DozerBeanMapperBuilder.java
@@ -461,6 +461,7 @@ public final class DozerBeanMapperBuilder {
         BeanContainer beanContainer = new BeanContainer();
         beanContainer.setElEngine(elEngine);
         beanContainer.setElementReader(elementReader);
+        beanContainer.setClassLoader(classLoader);
 
         DestBeanCreator destBeanCreator = new DestBeanCreator(beanContainer);
         destBeanCreator.setStoredFactories(beanFactories);


### PR DESCRIPTION
## Issue link
[ISSUE: 495] set classLoader of beanContainer

## Purpose
Custom class loader is not set to beanContainer so classes in mapping files provided by several OSGi bundles couldn't be resolved.

## Approach
Using custom aggregator classloader (that resolves application classes in all bundles) fixed the problem.

## Open Questions and Pre-Merge TODOs
- [X] Issue created
- [ ] Unit tests pass
- [ ] Documentation updated
- [x] Travis build passed
