### PR TITLE
Fixed minimal tests

### DIFF
--- a/tests/dozer-osgi-tests/src/test/java/com/github/dozermapper/osgitests/AbstractDozerCoreOsgiContainerTest.java
+++ b/tests/dozer-osgi-tests/src/test/java/com/github/dozermapper/osgitests/AbstractDozerCoreOsgiContainerTest.java
@@ -15,6 +15,7 @@
  */
 package com.github.dozermapper.osgitests;
 
+import com.github.dozermapper.osgitests.karaf.BundleOptions;
 import com.github.dozermapper.osgitests.support.OsgiTestSupport;
 import com.github.dozermapper.osgitestsmodel.Person;
 import org.dozer.DozerBeanMapperBuilder;
@@ -42,39 +43,12 @@ public abstract class AbstractDozerCoreOsgiContainerTest extends OsgiTestSupport
 
     @Configuration
     public Option[] config() {
-
         return options(
                 // Framework
                 containerConfigOptions(),
-                // Commons
-                localBundle("org.apache.commons.beanutils.link"),
-                localBundle("org.apache.commons.collections.link"),
-                localBundle("org.apache.commons.lang3.link"),
-                localBundle("org.apache.commons.io.link"),
-                // JAXB
-                localBundle("org.apache.geronimo.specs.geronimo-stax-api_1.0_spec.link"),
-                localBundle("org.apache.geronimo.specs.geronimo-activation_1.1_spec.link"),
-                localBundle("org.apache.servicemix.specs.jaxb-api-2.2.link"),
-                localBundle("org.apache.servicemix.bundles.jaxb-impl.link"),
-                // Jackson
-                localBundle("com.fasterxml.jackson.core.jackson-annotations.link"),
-                localBundle("com.fasterxml.jackson.core.jackson-core.link"),
-                localBundle("com.fasterxml.jackson.core.jackson-databind.link"),
-                localBundle("com.fasterxml.jackson.dataformat.jackson-dataformat-xml.link"),
-                localBundle("com.fasterxml.jackson.dataformat.jackson-dataformat-yaml.link"),
-                localBundle("com.fasterxml.jackson.module.jackson-module-jaxb-annotations.link"),
-                localBundle("com.fasterxml.woodstox.woodstox-core.link"),
-                localBundle("stax2-api.link"),
-                localBundle("org.yaml.snakeyaml.link"),
-                // Javassist
-                localBundle("javassist.link"),
-                // Optional;
+                // Bundles
                 optionalBundles(),
-                // Core
-                localBundle("com.github.dozermapper.dozer-core.link"),
-                localBundle("com.github.dozermapper.dozer-core.link"),
-                localBundle("com.github.dozermapper.dozer-schema.link"),
-                localBundle("com.github.dozermapper.tests.dozer-osgi-tests-model.link"),
+                BundleOptions.coreBundles(),
                 junitBundles()
         );
     }
@@ -82,7 +56,7 @@ public abstract class AbstractDozerCoreOsgiContainerTest extends OsgiTestSupport
     protected abstract Option containerConfigOptions();
 
     protected Option optionalBundles() {
-        return composite();
+        return BundleOptions.optionalBundles();
     }
 
     @Test
@@ -96,6 +70,13 @@ public abstract class AbstractDozerCoreOsgiContainerTest extends OsgiTestSupport
         assertEquals(Bundle.ACTIVE, core.getState());
 
         assertNull(bundleContext.getServiceReference(DozerModule.class));
+
+        for (Bundle current : bundleContext.getBundles()) {
+            //Ignore any Karaf bundles
+            if (!current.getSymbolicName().startsWith("org.apache.karaf")) {
+                assertEquals(current.getSymbolicName(), Bundle.ACTIVE, current.getState());
+            }
+        }
     }
 
     @Test
@@ -121,9 +102,4 @@ public abstract class AbstractDozerCoreOsgiContainerTest extends OsgiTestSupport
         assertNotNull(answer.getName());
         assertEquals("bob", answer.getName());
     }
-
-    InputStream getLocalResource(String name) {
-        return getClass().getClassLoader().getResourceAsStream(name);
-    }
-
 }

--- a/tests/dozer-osgi-tests/src/test/java/com/github/dozermapper/osgitests/DozerCoreMinimalDependenciesOsgiContainerTest.java
+++ b/tests/dozer-osgi-tests/src/test/java/com/github/dozermapper/osgitests/DozerCoreMinimalDependenciesOsgiContainerTest.java
@@ -17,14 +17,20 @@ package com.github.dozermapper.osgitests;
 
 import org.dozer.el.ELExpressionFactory;
 import org.junit.Test;
+import org.ops4j.pax.exam.Option;
 
 import static org.junit.Assert.assertFalse;
+import static org.ops4j.pax.exam.CoreOptions.composite;
 
 public abstract class DozerCoreMinimalDependenciesOsgiContainerTest extends AbstractDozerCoreOsgiContainerTest {
+
+    @Override
+    protected Option optionalBundles() {
+        return composite();
+    }
 
     @Test
     public void elNotSupported() {
         assertFalse(ELExpressionFactory.isSupported());
     }
-
 }

--- a/tests/dozer-osgi-tests/src/test/java/com/github/dozermapper/osgitests/DozerCoreOsgiContainerTest.java
+++ b/tests/dozer-osgi-tests/src/test/java/com/github/dozermapper/osgitests/DozerCoreOsgiContainerTest.java
@@ -21,23 +21,10 @@ import org.dozer.Mapper;
 import org.dozer.el.ELExpressionFactory;
 import org.dozer.osgi.OSGiClassLoader;
 import org.junit.Test;
-import org.ops4j.pax.exam.Option;
 
-import static com.github.dozermapper.osgitests.support.OptionsSupport.localBundle;
 import static org.junit.Assert.*;
-import static org.ops4j.pax.exam.CoreOptions.composite;
 
 public abstract class DozerCoreOsgiContainerTest extends AbstractDozerCoreOsgiContainerTest {
-
-    protected abstract Option containerConfigOptions();
-
-    protected Option optionalBundles() {
-        return composite(
-                // EL
-                localBundle("javax.el-api.link"),
-                localBundle("com.sun.el.javax.el.link")
-        );
-    }
 
     @Test
     public void canMapUsingXMLWithVariables() {

--- a/tests/dozer-osgi-tests/src/test/java/com/github/dozermapper/osgitests/karaf/BundleOptions.java
+++ b/tests/dozer-osgi-tests/src/test/java/com/github/dozermapper/osgitests/karaf/BundleOptions.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2005-2017 Dozer Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.dozermapper.osgitests.karaf;
+
+import org.ops4j.pax.exam.Option;
+
+import static com.github.dozermapper.osgitests.support.OptionsSupport.localBundle;
+import static org.ops4j.pax.exam.CoreOptions.composite;
+
+public final class BundleOptions {
+
+    public static Option coreBundles() {
+        return composite(
+                // Commons
+                localBundle("org.apache.commons.beanutils.link"),
+                localBundle("org.apache.commons.collections.link"),
+                localBundle("org.apache.commons.lang3.link"),
+                localBundle("org.apache.commons.io.link"),
+                // Core
+                localBundle("com.github.dozermapper.dozer-core.link"),
+                localBundle("com.github.dozermapper.dozer-schema.link"),
+                localBundle("com.github.dozermapper.tests.dozer-osgi-tests-model.link")
+        );
+    }
+
+    public static Option optionalBundles() {
+        return composite(
+                // Optional; Jackson
+                localBundle("com.fasterxml.jackson.core.jackson-annotations.link"),
+                localBundle("com.fasterxml.jackson.core.jackson-core.link"),
+                localBundle("com.fasterxml.jackson.core.jackson-databind.link"),
+                localBundle("com.fasterxml.jackson.dataformat.jackson-dataformat-xml.link"),
+                localBundle("com.fasterxml.jackson.dataformat.jackson-dataformat-yaml.link"),
+                localBundle("com.fasterxml.jackson.module.jackson-module-jaxb-annotations.link"),
+                localBundle("com.fasterxml.woodstox.woodstox-core.link"),
+                localBundle("stax2-api.link"),
+                localBundle("org.yaml.snakeyaml.link"),
+                // Optional; Javassist
+                localBundle("javassist.link"),
+                // Optional; EL
+                localBundle("javax.el-api.link"),
+                localBundle("com.sun.el.javax.el.link")
+        );
+    }
+}

--- a/tests/dozer-osgi-tests/src/test/java/com/github/dozermapper/osgitests/karaf/DozerCoreKaraf4MinimalDependenciesOsgiContainerTest.java
+++ b/tests/dozer-osgi-tests/src/test/java/com/github/dozermapper/osgitests/karaf/DozerCoreKaraf4MinimalDependenciesOsgiContainerTest.java
@@ -30,5 +30,4 @@ public class DozerCoreKaraf4MinimalDependenciesOsgiContainerTest extends DozerCo
     protected Option containerConfigOptions() {
         return KarafOptions.karaf4ContainerConfigOptions();
     }
-
 }

--- a/tests/dozer-osgi-tests/src/test/java/com/github/dozermapper/osgitests/karaf/DozerCoreKaraf4OsgiContainerTest.java
+++ b/tests/dozer-osgi-tests/src/test/java/com/github/dozermapper/osgitests/karaf/DozerCoreKaraf4OsgiContainerTest.java
@@ -30,5 +30,4 @@ public class DozerCoreKaraf4OsgiContainerTest extends DozerCoreOsgiContainerTest
     protected Option containerConfigOptions() {
         return KarafOptions.karaf4ContainerConfigOptions();
     }
-
 }

--- a/tests/dozer-osgi-tests/src/test/java/com/github/dozermapper/osgitests/karaf/KarafOptions.java
+++ b/tests/dozer-osgi-tests/src/test/java/com/github/dozermapper/osgitests/karaf/KarafOptions.java
@@ -48,7 +48,8 @@ public final class KarafOptions {
                         )
                         .karafVersion(version)
                         .name("Apache Karaf " + version)
-                        .unpackDirectory(new File("target/paxexam/unpack")),
+                        .unpackDirectory(new File("target/paxexam/unpack"))
+                        .useDeployFolder(false),
                 doNotModifyLogConfiguration()
         );
     }

--- a/tests/dozer-osgi-tests/src/test/java/com/github/dozermapper/osgitests/karaf/KarafOptions.java
+++ b/tests/dozer-osgi-tests/src/test/java/com/github/dozermapper/osgitests/karaf/KarafOptions.java
@@ -15,25 +15,25 @@
  */
 package com.github.dozermapper.osgitests.karaf;
 
-import org.ops4j.pax.exam.Option;
-import org.ops4j.pax.exam.karaf.options.LogLevelOption;
-
 import java.io.File;
+
+import org.ops4j.pax.exam.Option;
 
 import static org.ops4j.pax.exam.CoreOptions.composite;
 import static org.ops4j.pax.exam.CoreOptions.maven;
-import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.*;
+import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.karafDistributionConfiguration;
+import static org.ops4j.pax.exam.karaf.options.KarafDistributionOption.doNotModifyLogConfiguration;
 
-final class KarafOptions {
+public final class KarafOptions {
 
     private static final String FRAMEWORK_GROUP_ID = "org.apache.karaf";
     private static final String FRAMEWORK_ARTIFACT_ID = "apache-karaf";
 
-    static Option karaf4ContainerConfigOptions() {
+    public static Option karaf4ContainerConfigOptions() {
         return karafContainerConfigOptions("4.1.2");
     }
 
-    static Option karaf2ContainerConfigOptions() {
+    public static Option karaf2ContainerConfigOptions() {
         return karafContainerConfigOptions("2.4.4");
     }
 

--- a/tests/dozer-osgi-tests/src/test/java/com/github/dozermapper/osgitests/support/OptionsSupport.java
+++ b/tests/dozer-osgi-tests/src/test/java/com/github/dozermapper/osgitests/support/OptionsSupport.java
@@ -40,7 +40,9 @@ public final class OptionsSupport {
     public static UrlProvisionOption localBundle(String link) {
         try (InputStream resourceAsStream = OptionsSupport.class.getClassLoader().getResourceAsStream(link)) {
             List<String> urls = IOUtils.readLines(resourceAsStream, Charset.forName("UTF-8"));
+
             assertEquals("Invalid link file was provided", 1, urls.size());
+
             return url(urls.get(0));
         } catch (IOException e) {
             throw new IllegalArgumentException(e);

--- a/tests/dozer-osgi-tests/src/test/java/com/github/dozermapper/osgitests/support/OsgiTestSupport.java
+++ b/tests/dozer-osgi-tests/src/test/java/com/github/dozermapper/osgitests/support/OsgiTestSupport.java
@@ -15,6 +15,8 @@
  */
 package com.github.dozermapper.osgitests.support;
 
+import java.io.InputStream;
+
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 
@@ -30,5 +32,9 @@ public abstract class OsgiTestSupport {
         }
 
         return answer;
+    }
+
+    protected InputStream getLocalResource(String name) {
+        return getClass().getClassLoader().getResourceAsStream(name);
     }
 }


### PR DESCRIPTION
Noticed with the latest OSGi tests, that the minimal were actually installing a lot more than is needed. Also, the spring / proto were not running on a container either.