### PR TITLE
#172: Java 8 date and time support

### DIFF
--- a/bom-dependencies/pom.xml
+++ b/bom-dependencies/pom.xml
@@ -50,6 +50,7 @@
         <jaxb-impl.version>2.2.4</jaxb-impl.version>
         <jmh.version>1.19</jmh.version>
         <junit.version>4.12</junit.version>
+        <junit-params.version>1.1.1</junit-params.version>
         <mockito-core.version>2.9.0</mockito-core.version>
         <aries.spifly.verison>1.0.8</aries.spifly.verison>
         <pax-exam.version>4.11.0</pax-exam.version>
@@ -278,6 +279,11 @@
                 <groupId>org.objenesis</groupId>
                 <artifactId>objenesis</artifactId>
                 <version>${objenesis.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>pl.pragmatists</groupId>
+                <artifactId>JUnitParams</artifactId>
+                <version>${junit-params.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -173,6 +173,11 @@
             <artifactId>cglib-nodep</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>pl.pragmatists</groupId>
+            <artifactId>JUnitParams</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/core/src/main/java/org/dozer/converters/AbstractJava8DateTimeConverter.java
+++ b/core/src/main/java/org/dozer/converters/AbstractJava8DateTimeConverter.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2005-2017 Dozer Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dozer.converters;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.TemporalAccessor;
+
+import org.apache.commons.beanutils.Converter;
+
+/**
+ * Base converter to Java 8 date and time types.
+ * <pre>
+ * Supported basic conversions:
+ *  Any child of TemporalAccessor &#45;&gt; LocalDateTime
+ *  String &#45;&gt; LocalDateTime
+ * </pre>
+ */
+public abstract class AbstractJava8DateTimeConverter
+        implements Converter {
+
+    private final DateTimeFormatter formatter;
+
+    AbstractJava8DateTimeConverter(DateTimeFormatter formatter) {
+        this.formatter = formatter;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public Object convert(Class destClass, Object srcObject) {
+        Class<?> srcObjectClass = srcObject.getClass();
+        try {
+            if (TemporalAccessor.class.isAssignableFrom(srcObjectClass)) {
+                Method method = destClass.getDeclaredMethod("from", TemporalAccessor.class);
+                return method.invoke(null, ((TemporalAccessor) srcObject));
+            } else if (String.class.isAssignableFrom(srcObjectClass) && formatter != null) {
+
+                Method method = destClass.getDeclaredMethod("parse", CharSequence.class, DateTimeFormatter.class);
+                return method.invoke(null, srcObject, formatter);
+
+            } else {
+                throw new ConversionException(String.format("Unsupported source object type: %s", srcObjectClass), null);
+            }
+        } catch (NoSuchMethodException | IllegalAccessException e) {
+            throw new ConversionException(
+                    String.format("Failed to create %s from %s",
+                            destClass.getSimpleName(), srcObject.getClass().getSimpleName()),
+                    e);
+        } catch (InvocationTargetException e) {
+            throw new ConversionException(
+                    String.format("Failed to create %s from %s",
+                            destClass.getSimpleName(), srcObject.getClass().getSimpleName()),
+                    e.getTargetException());
+        }
+
+    }
+}

--- a/core/src/main/java/org/dozer/converters/DateFormatContainer.java
+++ b/core/src/main/java/org/dozer/converters/DateFormatContainer.java
@@ -17,34 +17,57 @@ package org.dozer.converters;
 
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
+import java.time.format.DateTimeFormatter;
 import java.util.Locale;
 
 /**
  * Internal class used as a container to determine the date format to use for a particular field mapping. Only intended
- * for internal use.  
- * 
+ * for internal use.
+ *
  * @author tierney.matt
  */
 public class DateFormatContainer {
-  private String dfStr;
-  private DateFormat dateFormat;
+    private String dfStr;
+    private DateFormat dateFormat;
+    private DateTimeFormatter dateTimeFormatter;
 
-  public DateFormatContainer(String dfStr) {
-    this.dfStr = dfStr;
-  }
-
-  public DateFormat getDateFormat() {
-    if (dateFormat == null) {
-      dateFormat = determineDateFormat();
+    public DateFormatContainer(String dfStr) {
+        this.dfStr = dfStr;
     }
-    return dateFormat;
-  }
 
-  public void setDateFormat(DateFormat dateFormat) {
-    this.dateFormat = dateFormat;
-  }
+    public DateFormat getDateFormat() {
+        if (dateFormat == null) {
+            dateFormat = determineDateFormat();
+        }
+        return dateFormat;
+    }
 
-  private DateFormat determineDateFormat() {
-    return dfStr == null ? null : new SimpleDateFormat(dfStr, Locale.getDefault());
-  }
+    /**
+     * Date and time formatter for Java 8 Date &amp; Time objects.
+     * @return formatter
+     */
+    public DateTimeFormatter getDateTimeFormatter() {
+        if (dateTimeFormatter == null) {
+            if (dfStr != null) {
+                dateTimeFormatter = DateTimeFormatter.ofPattern(dfStr);
+            }
+        }
+        return dateTimeFormatter;
+    }
+
+
+    /**
+     * TODO replace method call with reflection in tests.
+     * @param dateFormat dateFormat
+     * @deprecated This method will break internal state of the instance by setting formatter which is not using
+     * format provided using constructor. It will be removed in future releases.
+     */
+    @Deprecated
+    public void setDateFormat(DateFormat dateFormat) {
+        this.dateFormat = dateFormat;
+    }
+
+    private DateFormat determineDateFormat() {
+        return dfStr == null ? null : new SimpleDateFormat(dfStr, Locale.getDefault());
+    }
 }

--- a/core/src/main/java/org/dozer/converters/LocalDateTimeConverter.java
+++ b/core/src/main/java/org/dozer/converters/LocalDateTimeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2017 Dozer Project
+ * Copyright 2005-2018 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/converters/LocalDateTimeConverter.java
+++ b/core/src/main/java/org/dozer/converters/LocalDateTimeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2018 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/converters/LocalDateTimeConverter.java
+++ b/core/src/main/java/org/dozer/converters/LocalDateTimeConverter.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2005-2018 Dozer Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dozer.converters;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.Date;
+
+/**
+ * Internal converter to {@link LocalDateTime} type. Only intended for internal use.
+ * <pre>
+ * Supported conversions:
+ *  Any child of TemporalAccessor &#45;&gt; LocalDateTime ()
+ *  String &#45;&gt; LocalDateTime
+ *  Long &#45;&gt; LocalDateTime
+ *  Date &#45;&gt; LocalDateTime
+ * </pre>
+ */
+public final class LocalDateTimeConverter
+        extends AbstractJava8DateTimeConverter {
+
+    public LocalDateTimeConverter(DateTimeFormatter formatter) {
+        super(formatter);
+    }
+
+    @Override
+    public Object convert(Class destClass, Object srcObject) {
+        LocalDateTime localDateTime = convertToLocalDateTime(srcObject);
+        if (localDateTime != null) {
+            if (LocalTime.class.isAssignableFrom(destClass)) {
+                return localDateTime.toLocalTime();
+            } else if (LocalDate.class.isAssignableFrom(destClass)) {
+                return localDateTime.toLocalDate();
+            }
+            return localDateTime;
+        }
+        return super.convert(destClass, srcObject);
+    }
+
+
+    private LocalDateTime convertToLocalDateTime(Object srcObject) {
+        Class<?> srcObjectClass = srcObject.getClass();
+
+        if (Date.class.isAssignableFrom(srcObjectClass)) {
+            Instant instant = ((Date) srcObject).toInstant();
+            return LocalDateTime.ofInstant(instant, ZoneId.systemDefault());
+        } else if (Instant.class.isAssignableFrom(srcObjectClass)) {
+            return LocalDateTime.ofInstant(((Instant) srcObject), ZoneId.systemDefault());
+        } else if (Long.class.isAssignableFrom(srcObjectClass)) {
+            Instant instant = Instant.ofEpochMilli((Long) srcObject);
+            return LocalDateTime.ofInstant(instant, ZoneId.systemDefault());
+        } else {
+            return null;
+        }
+    }
+}

--- a/core/src/main/java/org/dozer/converters/OffsetDateTimeConverter.java
+++ b/core/src/main/java/org/dozer/converters/OffsetDateTimeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2017 Dozer Project
+ * Copyright 2005-2018 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/converters/OffsetDateTimeConverter.java
+++ b/core/src/main/java/org/dozer/converters/OffsetDateTimeConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2018 Dozer Project
+ * Copyright 2005-2017 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/dozer/converters/OffsetDateTimeConverter.java
+++ b/core/src/main/java/org/dozer/converters/OffsetDateTimeConverter.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2005-2018 Dozer Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dozer.converters;
+
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.OffsetTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.Date;
+
+/**
+ * Internal class for converting supported types to {@link java.time.OffsetDateTime}.
+ * Only intended for internal use.
+ *
+ * @author vadeg
+ */
+public class OffsetDateTimeConverter
+        extends AbstractJava8DateTimeConverter {
+
+    public OffsetDateTimeConverter(DateTimeFormatter formatter) {
+        super(formatter);
+    }
+
+    @Override
+    public Object convert(Class destClass, Object srcObject) {
+        OffsetDateTime offsetDateTime = convertToOffsetDateTime(srcObject);
+        if (offsetDateTime != null) {
+            if (OffsetTime.class.isAssignableFrom(destClass)) {
+                return offsetDateTime.toOffsetTime();
+            }
+            return offsetDateTime;
+        }
+        return super.convert(destClass, srcObject);
+    }
+
+    private OffsetDateTime convertToOffsetDateTime(Object srcObject) {
+        Class<?> srcObjectClass = srcObject.getClass();
+        if (Date.class.isAssignableFrom(srcObjectClass)) {
+            Instant instant = ((Date) srcObject).toInstant();
+            return OffsetDateTime.ofInstant(instant, ZoneId.systemDefault());
+        } else if (Instant.class.isAssignableFrom(srcObjectClass)) {
+            return OffsetDateTime.ofInstant(((Instant) srcObject), ZoneId.systemDefault());
+        } else if (Long.class.isAssignableFrom(srcObjectClass)) {
+            Instant instant = Instant.ofEpochMilli((Long) srcObject);
+            return OffsetDateTime.ofInstant(instant, ZoneId.systemDefault());
+        } else {
+            return null;
+        }
+    }
+}

--- a/core/src/main/java/org/dozer/converters/PrimitiveOrWrapperConverter.java
+++ b/core/src/main/java/org/dozer/converters/PrimitiveOrWrapperConverter.java
@@ -15,14 +15,19 @@
  */
 package org.dozer.converters;
 
+import javax.xml.bind.JAXBElement;
+import javax.xml.datatype.XMLGregorianCalendar;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.OffsetTime;
+import java.time.ZonedDateTime;
 import java.util.Calendar;
 import java.util.HashMap;
 import java.util.Map;
-
-import javax.xml.bind.JAXBElement;
-import javax.xml.datatype.XMLGregorianCalendar;
 
 import org.apache.commons.beanutils.Converter;
 import org.apache.commons.beanutils.converters.BigDecimalConverter;
@@ -110,6 +115,12 @@ public class PrimitiveOrWrapperConverter {
                 result = new EnumConverter();
             } else if (JAXBElement.class.isAssignableFrom(destClass) && destFieldName != null) {
                 result = new JAXBElementConverter(destObj.getClass().getCanonicalName(), destFieldName, dateFormatContainer.getDateFormat(), beanContainer);
+            } else if (isLocalTime(destClass)) {
+                result = new LocalDateTimeConverter(dateFormatContainer.getDateTimeFormatter());
+            } else if (isOffsetTime(destClass)) {
+                result = new OffsetDateTimeConverter(dateFormatContainer.getDateTimeFormatter());
+            } else if (ZonedDateTime.class.isAssignableFrom(destClass)) {
+                result = new ZonedDateTimeConverter(dateFormatContainer.getDateTimeFormatter());
             }
         }
         return result == null ? new StringConstructorConverter(dateFormatContainer) : result;
@@ -122,7 +133,24 @@ public class PrimitiveOrWrapperConverter {
                        || Character.class.equals(aClass)
                        || Boolean.class.equals(aClass)
                        || java.util.Date.class.isAssignableFrom(aClass)
-                       || java.util.Calendar.class.isAssignableFrom(aClass);
+                       || java.util.Calendar.class.isAssignableFrom(aClass)
+                       || LocalDateTime.class.isAssignableFrom(aClass)
+                       || LocalDate.class.isAssignableFrom(aClass)
+                       || LocalTime.class.isAssignableFrom(aClass)
+                       || OffsetDateTime.class.isAssignableFrom(aClass)
+                       || OffsetTime.class.isAssignableFrom(aClass)
+                       || ZonedDateTime.class.isAssignableFrom(aClass);
+    }
+
+    private static boolean isLocalTime(Class clazz) {
+        return LocalDateTime.class.isAssignableFrom(clazz) ||
+                LocalDate.class.isAssignableFrom(clazz) ||
+                LocalTime.class.isAssignableFrom(clazz);
+    }
+
+    private static boolean isOffsetTime(Class clazz) {
+        return OffsetDateTime.class.isAssignableFrom(clazz) ||
+                OffsetTime.class.isAssignableFrom(clazz);
     }
 
 }

--- a/core/src/main/java/org/dozer/converters/StringConverter.java
+++ b/core/src/main/java/org/dozer/converters/StringConverter.java
@@ -16,42 +16,52 @@
 package org.dozer.converters;
 
 
+import java.time.temporal.TemporalAccessor;
+import java.util.Calendar;
+import java.util.Date;
+
 import org.apache.commons.beanutils.Converter;
 
 /**
  * Internal class for converting Supported Data Types to String. Uses date formatter for Date and Calendar source
- * objects. Calls toString() on the source object for all other types. Only intended for internal use.
- * 
+ * objects. Calls toString() on the source object for all other types. c
+ *
  * @author tierney.matt
  */
 public class StringConverter implements Converter {
-  private DateFormatContainer dateFormatContainer;
 
-  public StringConverter(DateFormatContainer dateFormatContainer) {
-    this.dateFormatContainer = dateFormatContainer;
-  }
+    private DateFormatContainer dateFormatContainer;
 
-  public Object convert(Class destClass, Object srcObj) {
-    String result;
-    Class srcClass = srcObj.getClass();
-    if (dateFormatContainer != null && java.util.Date.class.isAssignableFrom(srcClass)
-        && dateFormatContainer.getDateFormat() != null) {
-      result = dateFormatContainer.getDateFormat().format((java.util.Date) srcObj);
-    } else if (dateFormatContainer != null && java.util.Calendar.class.isAssignableFrom(srcClass)
-        && dateFormatContainer.getDateFormat() != null) {
-      result = dateFormatContainer.getDateFormat().format(((java.util.Calendar) srcObj).getTime());
-    } else {
-      result = srcObj.toString();
+    public StringConverter(DateFormatContainer dateFormatContainer) {
+        this.dateFormatContainer = dateFormatContainer;
     }
 
-    return result;
-  }
+    public Object convert(Class destClass, Object srcObj) {
+        Class srcClass = srcObj.getClass();
+        if (hasDateFormat()) {
+            if (Date.class.isAssignableFrom(srcClass)) {
+                return dateFormatContainer.getDateFormat().format((Date) srcObj);
+            }
+            if (Calendar.class.isAssignableFrom(srcClass)) {
+                return dateFormatContainer.getDateFormat().format(((Calendar) srcObj).getTime());
+            } else if (TemporalAccessor.class.isAssignableFrom(srcClass)) {
+                return dateFormatContainer.getDateTimeFormatter().format(((TemporalAccessor) srcObj));
+            } else {
+                return srcObj.toString();
+            }
+        } else {
+            return srcObj.toString();
+        }
+    }
 
-  public DateFormatContainer getDateFormatContainer() {
-    return dateFormatContainer;
-  }
+    /**
+     * Whether date format is provided or not
+     *
+     * @return true - date format provided. Otherwise false.
+     */
+    private boolean hasDateFormat() {
+        return dateFormatContainer != null && dateFormatContainer.getDateFormat() != null;
+    }
 
-  public void setDateFormatContainer(DateFormatContainer dateFormat) {
-    this.dateFormatContainer = dateFormat;
-  }
+
 }

--- a/core/src/main/java/org/dozer/converters/ZonedDateTimeConverter.java
+++ b/core/src/main/java/org/dozer/converters/ZonedDateTimeConverter.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2005-2017 Dozer Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dozer.converters;
+
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Date;
+
+/**
+ * Internal class for converting supported types to {@link java.time.ZonedDateTime}.
+ * Only intended for internal use.
+ *
+ * @author vadeg
+ */
+
+public class ZonedDateTimeConverter
+    extends AbstractJava8DateTimeConverter {
+
+    public ZonedDateTimeConverter(DateTimeFormatter formatter) {
+        super(formatter);
+    }
+
+    @Override
+    public Object convert(Class destClass, Object srcObject) {
+        Class<?> srcObjectClass = srcObject.getClass();
+        if (Date.class.isAssignableFrom(srcObjectClass)) {
+            Instant instant = ((Date) srcObject).toInstant();
+            return ZonedDateTime.ofInstant(instant, ZoneId.systemDefault());
+        } else if (Instant.class.isAssignableFrom(srcObjectClass)) {
+            return ZonedDateTime.ofInstant(((Instant) srcObject), ZoneId.systemDefault());
+        } else if (Long.class.isAssignableFrom(srcObjectClass)) {
+            Instant instant = Instant.ofEpochMilli((Long) srcObject);
+            return ZonedDateTime.ofInstant(instant, ZoneId.systemDefault());
+        } else {
+            return super.convert(destClass, srcObject);
+        }
+
+    }
+}

--- a/core/src/test/java/org/dozer/converters/ConverterTest.java
+++ b/core/src/test/java/org/dozer/converters/ConverterTest.java
@@ -24,21 +24,6 @@ import org.junit.Test;
  * @author tierney.matt
  */
 public class ConverterTest extends AbstractDozerTest {
-  /*
-   * See PrimitiveOrWrapperConverterTest for more thorough data conversion unit tests
-   */
-  @Test
-  public void testAccessors() throws Exception {
-    DateFormat dateFormat = DateFormat.getDateInstance(DateFormat.LONG);
-
-    CalendarConverter cc = new CalendarConverter(dateFormat);
-    assertEquals(dateFormat, cc.getDateFormat());
-
-    StringConverter sc = new StringConverter(null);
-    DateFormatContainer dfc = new DateFormatContainer(null);
-    sc.setDateFormatContainer(dfc);
-    assertEquals(dfc, sc.getDateFormatContainer());
-  }
 
   @Test(expected = ConversionException.class)
   public void testInvalidDateInput() throws Exception {
@@ -48,9 +33,8 @@ public class ConverterTest extends AbstractDozerTest {
 
   @Test(expected = ConversionException.class)
   public void testInvalidDateInput_String() throws Exception {
-    DateConverter dc = new DateConverter(DateFormat.getDateInstance(DateFormat.LONG));
     // no long constructor
-    dc = new DateConverter(null);
+    DateConverter dc = new DateConverter(null);
     dc.convert(String.class, "123");
   }
 

--- a/core/src/test/java/org/dozer/converters/LocalDateTimeConverterTest.java
+++ b/core/src/test/java/org/dozer/converters/LocalDateTimeConverterTest.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2005-2017 Dozer Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dozer.converters;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Date;
+
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(JUnitParamsRunner.class)
+public class LocalDateTimeConverterTest {
+
+    private LocalDateTimeConverter localTimeConverter = new LocalDateTimeConverter(DateTimeFormatter.ISO_LOCAL_TIME);
+    private LocalDateTimeConverter localDateTimeConverter =
+            new LocalDateTimeConverter(DateTimeFormatter.ISO_LOCAL_DATE_TIME);
+    private LocalDateTimeConverter localDateConverter = new LocalDateTimeConverter(DateTimeFormatter.ISO_LOCAL_DATE);
+
+    @Test
+    @Parameters(method = "localDateTimeTestData")
+    public void testLocalDateTimeConverter(Object sourceObject, LocalDateTime expectedResult) {
+        LocalDateTime result = (LocalDateTime) localDateTimeConverter.convert(LocalDateTime.class, sourceObject);
+        assertTrue(
+                String.format("%s is not equal to %s", result, expectedResult), expectedResult.isEqual(result)
+        );
+    }
+
+    @Test
+    @Parameters(method = "localDateTestData")
+    public void testLocalDateConverter(Object sourceObject, LocalDate expectedResult) {
+        LocalDate result = (LocalDate) localDateConverter.convert(LocalDate.class, sourceObject);
+        assertTrue(
+                String.format("%s is not equal to %s", result, expectedResult), expectedResult.isEqual(result)
+        );
+    }
+
+    @Test
+    @Parameters(method = "localTimeTestData")
+    public void testLocalTimeConverter(Object sourceObject, LocalTime expectedResult) {
+        LocalTime result = (LocalTime) localTimeConverter.convert(LocalTime.class, sourceObject);
+        assertEquals(expectedResult, result);
+    }
+
+    @Test(expected = ConversionException.class)
+    public void testThrowExceptionWhenSourceNotSupported() {
+        localTimeConverter.convert(LocalDateTime.class, 'a');
+    }
+
+    /**
+     * Test data for
+     * {@link LocalDateTimeConverterTest#testLocalDateTimeConverter(Object, LocalDateTime)} method.
+     *
+     * @return test data
+     */
+    private Object localTimeTestData() {
+        return new Object[][]{
+                {
+                        LocalTime.of(10, 20, 30),
+                        LocalTime.of(10, 20, 30)
+                },
+                {
+                        OffsetDateTime.parse("2017-11-02T10:20:30+02:00"),
+                        LocalTime.of(10, 20, 30)
+                },
+                {
+                        "10:20:30",
+                        LocalTime.of(10, 20, 30)
+                },
+                {
+                        Instant.parse("2017-11-02T10:20:30.00Z").toEpochMilli(),
+                        LocalDateTime
+                                .ofInstant(Instant.parse("2017-11-02T10:20:30.00Z"), ZoneId.systemDefault())
+                                .toLocalTime()
+                },
+                {
+                        new Date(Instant.parse("2017-11-02T10:20:30.00Z").toEpochMilli()),
+                        LocalDateTime
+                                .ofInstant(Instant.parse("2017-11-02T10:20:30.00Z"), ZoneId.systemDefault())
+                                .toLocalTime()
+                }
+        };
+    }
+
+    /**
+     * Test data for {@link LocalDateTimeConverterTest#testLocalDateConverter(Object, LocalDate)} method.
+     *
+     * @return test data
+     */
+    private Object localDateTestData() {
+        return new Object[][]{
+                {
+                        LocalDate.of(2017, 11, 2),
+                        LocalDate.of(2017, 11, 2)
+                },
+                {
+                        OffsetDateTime.parse("2017-11-02T10:20:30+02:00"),
+                        LocalDate.of(2017, 11, 2)
+                },
+                {
+                        "2017-11-02",
+                        LocalDate.of(2017, 11, 2)
+                },
+                {
+                        Instant.parse("2017-11-02T10:20:30.00Z").toEpochMilli(),
+                        LocalDate.of(2017, 11, 2)
+                },
+                {
+                        new Date(Instant.parse("2017-11-02T10:20:30.00Z").toEpochMilli()),
+                        LocalDate.of(2017, 11, 2)
+                }
+        };
+    }
+
+    /**
+     * Test data for {@link LocalDateTimeConverterTest#testLocalTimeConverter(Object, LocalTime)} method.
+     *
+     * @return test data
+     */
+    private Object localDateTimeTestData() {
+        return new Object[][]{
+                {
+                        LocalDateTime.of(2017, 11, 2, 10, 0),
+                        LocalDateTime.of(2017, 11, 2, 10, 0)
+                },
+                {
+                        OffsetDateTime.parse("2017-11-02T10:20:30+02:00"),
+                        OffsetDateTime.parse("2017-11-02T10:20:30+02:00").toLocalDateTime()
+                },
+                {
+                        ZonedDateTime.parse("2017-11-02T10:20:30+02:00[Europe/Paris]"),
+                        ZonedDateTime.parse("2017-11-02T10:20:30+02:00[Europe/Paris]").toLocalDateTime()
+                },
+                {
+                        "2017-11-02T10:20:30",
+                        LocalDateTime.parse("2017-11-02T10:20:30")
+                },
+                {
+                        Instant.parse("2017-11-02T10:20:30.00Z"),
+                        LocalDateTime.ofInstant(Instant.parse("2017-11-02T10:20:30.00Z"), ZoneId.systemDefault())
+                },
+                {
+                        Instant.parse("2017-11-02T10:20:30.00Z").toEpochMilli(),
+                        LocalDateTime
+                                .ofInstant(Instant.parse("2017-11-02T10:20:30.00Z"), ZoneId.systemDefault())
+                },
+        };
+    }
+}

--- a/core/src/test/java/org/dozer/converters/OffsetDateTimeConverterTest.java
+++ b/core/src/test/java/org/dozer/converters/OffsetDateTimeConverterTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2005-2017 Dozer Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dozer.converters;
+
+import java.time.Instant;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.OffsetTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Date;
+
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+import static org.junit.Assert.assertTrue;
+
+@RunWith(JUnitParamsRunner.class)
+public class OffsetDateTimeConverterTest {
+
+    @Test
+    @Parameters(method = "offsetDateTimeTestData")
+    public void testOffsetDateTimeConverter(
+            Object sourceObject, OffsetDateTime expectedResult)
+            throws Exception {
+        OffsetDateTime result = (OffsetDateTime) new OffsetDateTimeConverter(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+                .convert(OffsetDateTime.class, sourceObject);
+        assertTrue(expectedResult.isEqual(result));
+    }
+
+    @Test
+    @Parameters(method = "offsetTimeTestData")
+    public void testOffsetTimeConverter(
+            Object sourceObject, OffsetTime expectedResult)
+            throws Exception {
+        OffsetTime result = (OffsetTime) new OffsetDateTimeConverter(DateTimeFormatter.ISO_OFFSET_TIME)
+                .convert(OffsetTime.class, sourceObject);
+        assertTrue(expectedResult.isEqual(result));
+    }
+
+    /**
+     * Test data for
+     * {@link OffsetDateTimeConverterTest#testOffsetDateTimeConverter(Object, OffsetDateTime)} method.
+     * @return test data
+     */
+    private Object offsetDateTimeTestData() {
+        return new Object[][]{
+                {
+                        OffsetDateTime.of(2017, 11, 2, 10, 20, 30, 0, ZoneOffset.UTC),
+                        OffsetDateTime.of(2017, 11, 2, 10, 20, 30, 0, ZoneOffset.UTC)
+                },
+                {
+                        OffsetDateTime.parse("2017-11-02T10:20:30+02:00"),
+                        OffsetDateTime.of(2017, 11, 2, 10, 20, 30, 0, ZoneOffset.ofHours(2))
+                },
+                {
+                        ZonedDateTime.parse("2017-11-02T10:20:30+01:00[Europe/Paris]"),
+                        OffsetDateTime.of(2017, 11, 2, 10, 20, 30, 0, ZoneOffset.ofHours(1))
+                },
+                {
+                        "2017-11-02T10:20:30+02:00",
+                        OffsetDateTime.of(2017, 11, 2, 10, 20, 30, 0, ZoneOffset.ofHours(2))
+                },
+                {
+                        Instant.parse("2017-11-02T10:20:30.00Z"),
+                        OffsetDateTime.ofInstant(Instant.parse("2017-11-02T10:20:30.00Z"), ZoneId.systemDefault())
+                },
+                {
+                        Instant.parse("2017-11-02T10:20:30.00Z").toEpochMilli(),
+                        OffsetDateTime.ofInstant(Instant.parse("2017-11-02T10:20:30.00Z"), ZoneId.systemDefault())
+                },
+                {
+                        new Date(Instant.parse("2017-11-02T10:20:30.00Z").toEpochMilli()),
+                        OffsetDateTime.ofInstant(Instant.parse("2017-11-02T10:20:30.00Z"), ZoneId.systemDefault())
+                }
+        };
+    }
+
+    /**
+     * Test data for
+     * {@link OffsetDateTimeConverterTest#testOffsetTimeConverter(Object, OffsetTime)} method.
+     * @return test data
+     */
+    private Object offsetTimeTestData() {
+        return new Object[][] {
+                {
+                        OffsetTime.of(LocalTime.of(10, 20, 30), ZoneOffset.ofHours(2)),
+                        OffsetTime.of(LocalTime.of(10, 20, 30), ZoneOffset.ofHours(2))
+                },
+                {
+                        "10:20:30+04:00",
+                        OffsetTime.of(LocalTime.of(10, 20, 30), ZoneOffset.ofHours(4))
+                },
+                {
+                        Instant.parse("2017-11-02T10:20:30.00Z").toEpochMilli(),
+                        OffsetDateTime
+                                .ofInstant(Instant.parse("2017-11-02T10:20:30.00Z"), ZoneId.systemDefault())
+                                .toOffsetTime()
+                },
+                {
+                        new Date(Instant.parse("2017-11-02T10:20:30.00Z").toEpochMilli()),
+                        OffsetDateTime
+                                .ofInstant(Instant.parse("2017-11-02T10:20:30.00Z"), ZoneId.systemDefault())
+                                .toOffsetTime()
+                }
+        };
+    }
+}

--- a/core/src/test/java/org/dozer/converters/StringConverterTest.java
+++ b/core/src/test/java/org/dozer/converters/StringConverterTest.java
@@ -15,28 +15,49 @@
  */
 package org.dozer.converters;
 
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Calendar;
 import java.util.Date;
 
 import org.dozer.AbstractDozerTest;
 import org.junit.Test;
 
-public class StringConverterTest extends AbstractDozerTest{
+public class StringConverterTest extends AbstractDozerTest {
 
-  @Test
-  public void testDateToString_NoDateFormatSpecified() {
-    Date src = new Date();
-    StringConverter converter = new StringConverter(new DateFormatContainer(null));
-    String result = (String) converter.convert(String.class, src);
-    assertEquals("incorrect value returned from converter", src.toString(), result);
-  }
+    @Test
+    public void testDateToString_NoDateFormatSpecified() {
+        Date src = new Date();
+        StringConverter converter = new StringConverter(new DateFormatContainer(null));
+        String result = (String) converter.convert(String.class, src);
+        assertEquals("incorrect value returned from converter", src.toString(), result);
+    }
 
-  @Test
-  public void testCalendarToString_NoDateFormatSpecified() {
-    Calendar src = Calendar.getInstance();
-    StringConverter converter = new StringConverter(new DateFormatContainer(null));
-    String result = (String) converter.convert(String.class, src);
-    assertEquals("incorrect value returned from converter", src.toString(), result);
-  }
+    @Test
+    public void testCalendarToString_NoDateFormatSpecified() {
+        Calendar src = Calendar.getInstance();
+        StringConverter converter = new StringConverter(new DateFormatContainer(null));
+        String result = (String) converter.convert(String.class, src);
+        assertEquals("incorrect value returned from converter", src.toString(), result);
+    }
+
+    @Test
+    public void testLocalDateTimeToStringNoFormat() {
+        LocalDateTime src = LocalDateTime.now();
+        StringConverter converter = new StringConverter(new DateFormatContainer(null));
+        String result = (String) converter.convert(String.class, src);
+        assertEquals("incorrect value returned from converter", src.toString(), result);
+    }
+
+    @Test
+    public void testLocalDateTimeToStringWithFormat() {
+        LocalDateTime src = LocalDateTime.now();
+        String pattern = "yyyy-MM-dd'T'HH:mm:ss";
+        String formattedSrc = DateTimeFormatter.ofPattern(pattern).format(src);
+
+        StringConverter converter = new StringConverter(new DateFormatContainer(pattern));
+        String result = (String) converter.convert(String.class, src);
+        assertEquals("incorrect value returned from converter", formattedSrc, result);
+    }
 
 }

--- a/core/src/test/java/org/dozer/converters/ZonedDateTimeConverterTest.java
+++ b/core/src/test/java/org/dozer/converters/ZonedDateTimeConverterTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2005-2017 Dozer Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dozer.converters;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Date;
+
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(JUnitParamsRunner.class)
+public class ZonedDateTimeConverterTest {
+
+    private final ZonedDateTimeConverter converter = new ZonedDateTimeConverter(DateTimeFormatter.ISO_ZONED_DATE_TIME);
+
+    @Test
+    @Parameters(method = "testData")
+    public void testConverter(Object sourceObject, Object expected) {
+        Object result = converter.convert(ZonedDateTime.class, sourceObject);
+        assertEquals(expected, result);
+        assertTrue(result instanceof ZonedDateTime);
+    }
+
+    private Object testData() {
+        return new Object[][]{
+                {
+                        ZonedDateTime.of(
+                                LocalDateTime.of(2017, 11, 2, 10, 0),
+                                ZoneId.systemDefault()
+                        ),
+                        ZonedDateTime.of(
+                                LocalDateTime.of(2017, 11, 2, 10, 0),
+                                ZoneId.systemDefault()
+                        ),
+                },
+
+                {
+                        "2017-11-02T10:20:30+08:00[Europe/Madrid]",
+                        ZonedDateTime.of(
+                                LocalDateTime.of(2017, 11, 2, 10, 20, 30),
+                                ZoneId.of("Europe/Madrid")
+                        )
+                },
+
+                {
+                        Instant.parse("2017-11-02T10:20:30.00Z"),
+                        ZonedDateTime.ofInstant(Instant.parse("2017-11-02T10:20:30.00Z"), ZoneId.systemDefault())
+                },
+
+                {
+                        Instant.parse("2017-11-02T10:20:30.00Z").toEpochMilli(),
+                        ZonedDateTime.ofInstant(Instant.parse("2017-11-02T10:20:30.00Z"), ZoneId.systemDefault())
+
+
+                },
+
+                {
+                        new Date(Instant.parse("2017-11-02T10:20:30.00Z").toEpochMilli()),
+                        ZonedDateTime.ofInstant(Instant.parse("2017-11-02T10:20:30.00Z"), ZoneId.systemDefault())
+                }
+        };
+    }
+}

--- a/core/src/test/java/org/dozer/functional_tests/LocalDateTimeMappingTest.java
+++ b/core/src/test/java/org/dozer/functional_tests/LocalDateTimeMappingTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2005-2017 Dozer Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dozer.functional_tests;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+import org.dozer.Mapper;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(JUnitParamsRunner.class)
+public class LocalDateTimeMappingTest
+        extends AbstractFunctionalTest {
+
+    private final LocalDate sampleLocalDate = LocalDate.of(2017, 11, 2);
+    private final LocalDateTime sample = LocalDateTime.of(2017, 11, 2, 10, 20, 30);
+    private final ZoneOffset sampleOffset = ZoneId.systemDefault().getRules().getOffset(sample);
+    private Mapper mapper;
+
+    @Before
+    public void setUp() throws Exception {
+        mapper = getMapper("mappings/jsr330Mapping.xml");
+    }
+
+    @Test
+    @Parameters(method = "localDateTimeTestData")
+    public void testLocalDateTimeMapping(Object source) {
+        Map<String, Object> sourceMap = new HashMap<>();
+        sourceMap.put("key", source);
+        LocalDateTimeVO dest = mapper.map(sourceMap, LocalDateTimeVO.class);
+        assertNotNull(dest);
+        LocalDateTime result = dest.getResult();
+        assertTrue(
+                String.format("Values are not equals. Expected: %s. Actual: %s", sample, result),
+                sample.isEqual(result)
+        );
+    }
+
+    @Test
+    @Parameters(method = "localDateTestData")
+    public void testLocalDateMapping(Object source) {
+        Map<String, Object> sourceMap = new HashMap<>();
+        sourceMap.put("key", source);
+        LocalDateVO dest = mapper.map(sourceMap, LocalDateVO.class);
+        assertNotNull(dest);
+        LocalDate result = dest.getResult();
+        assertTrue(
+                String.format("Values are not equals. Expected: %s. Actual: %s", sampleLocalDate, result),
+                sampleLocalDate.isEqual(result)
+        );
+    }
+
+    private Object localDateTestData() {
+        return new Object[][]{
+                {DateTimeFormatter.ISO_LOCAL_DATE.format(sampleLocalDate)}
+        };
+    }
+
+    private Object localDateTimeTestData() {
+        return new Object[][]{
+                {DateTimeFormatter.ISO_LOCAL_DATE_TIME.format(sample)},
+                {sample.toInstant(sampleOffset)},
+                {sample.toInstant(sampleOffset).toEpochMilli()},
+                {new Date(sample.toInstant(sampleOffset).toEpochMilli())}
+        };
+    }
+
+    public static final class LocalDateTimeVO {
+
+        private LocalDateTime result;
+
+        public LocalDateTime getResult() {
+            return result;
+        }
+
+        public LocalDateTimeVO setResult(LocalDateTime result) {
+            this.result = result;
+            return this;
+        }
+    }
+
+    public static final class LocalDateVO {
+
+        private LocalDate result;
+
+        public LocalDate getResult() {
+            return result;
+        }
+
+        public LocalDateVO setResult(LocalDate result) {
+            this.result = result;
+            return this;
+        }
+    }
+
+}

--- a/core/src/test/java/org/dozer/functional_tests/OffsetDateTimeMappingTest.java
+++ b/core/src/test/java/org/dozer/functional_tests/OffsetDateTimeMappingTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2005-2017 Dozer Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dozer.functional_tests;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+import org.dozer.Mapper;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(JUnitParamsRunner.class)
+public class OffsetDateTimeMappingTest
+        extends AbstractFunctionalTest {
+
+    private final OffsetDateTime offsetDateTimeSample = OffsetDateTime.of(2017, 11, 2, 10, 20, 30, 0, ZoneOffset.ofHours(2));
+
+    private Mapper mapper;
+
+    @Before
+    public void setUp() throws Exception {
+        mapper = getMapper("mappings/jsr330Mapping.xml");
+    }
+
+    @Test
+    @Parameters(method = "testData")
+    public void testMapping(Object source) {
+        Map<String, Object> sourceMap = new HashMap<>();
+        sourceMap.put("key", source);
+        OffsetDateTimeVO dest = mapper.map(sourceMap, OffsetDateTimeVO.class);
+        assertNotNull(dest);
+        OffsetDateTime result = dest.getResult();
+        assertTrue(
+                String.format("Values are not equals. Expected: %s. Actual: %s", offsetDateTimeSample, result),
+                offsetDateTimeSample.isEqual(result)
+        );
+    }
+
+    private Object testData() {
+        return new Object[][]{
+                {DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(offsetDateTimeSample)},
+                {offsetDateTimeSample.toInstant()},
+                {offsetDateTimeSample.toInstant().toEpochMilli()},
+                {new Date(offsetDateTimeSample.toInstant().toEpochMilli())}
+        };
+    }
+
+    public static class OffsetDateTimeVO {
+
+        private OffsetDateTime result;
+
+        public OffsetDateTime getResult() {
+            return result;
+        }
+
+        public void setResult(OffsetDateTime result) {
+            this.result = result;
+        }
+    }
+}

--- a/core/src/test/java/org/dozer/functional_tests/ZonedDateTimeMappingTest.java
+++ b/core/src/test/java/org/dozer/functional_tests/ZonedDateTimeMappingTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2005-2017 Dozer Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dozer.functional_tests;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+import org.dozer.Mapper;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(JUnitParamsRunner.class)
+public class ZonedDateTimeMappingTest
+        extends AbstractFunctionalTest {
+
+    private Mapper mapper;
+
+    private ZonedDateTime sample = ZonedDateTime.of(
+            LocalDateTime.of(2017, 11, 2, 10, 0),
+            ZoneId.systemDefault()
+    );
+
+
+    @Before
+    public void setUp() throws Exception {
+        mapper = getMapper("mappings/jsr330Mapping.xml");
+    }
+
+
+    @Test
+    @Parameters(method = "testData")
+    public void testMapping(Object source) {
+        Map<String, Object> sourceMap = new HashMap<>();
+        sourceMap.put("key", source);
+        ZonedDateTimeVO dest = mapper.map(sourceMap, ZonedDateTimeVO.class);
+        assertNotNull(dest);
+        ZonedDateTime result = dest.getResult();
+        assertTrue(
+                String.format("Values are not equals. Expected: %s. Actual: %s", sample, result),
+                sample.isEqual(result)
+        );
+    }
+
+    private Object testData() {
+        return new Object[][]{
+                {DateTimeFormatter.ISO_ZONED_DATE_TIME.format(sample)},
+                {sample.toInstant()},
+                {sample.toInstant().toEpochMilli()},
+                {new Date(sample.toInstant().toEpochMilli())}
+        };
+    }
+
+    public static class ZonedDateTimeVO {
+
+        private ZonedDateTime result;
+
+        public ZonedDateTime getResult() {
+            return result;
+        }
+
+        public void setResult(ZonedDateTime result) {
+            this.result = result;
+        }
+    }
+
+}

--- a/core/src/test/resources/mappings/jsr330Mapping.xml
+++ b/core/src/test/resources/mappings/jsr330Mapping.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2005-2017 Dozer Project
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<mappings xmlns="http://dozermapper.github.io/schema/bean-mapping"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://dozermapper.github.io/schema/bean-mapping http://dozermapper.github.io/schema/bean-mapping.xsd">
+
+    <mapping>
+        <class-a>java.util.HashMap</class-a>
+        <class-b>org.dozer.functional_tests.OffsetDateTimeMappingTest.OffsetDateTimeVO</class-b>
+        <field>
+            <a key="key" date-format="yyyy-MM-dd'T'HH:mm:ssZZZZZ">this</a>
+            <b>result</b>
+        </field>
+    </mapping>
+
+    <mapping>
+        <class-a>java.util.HashMap</class-a>
+        <class-b>org.dozer.functional_tests.LocalDateTimeMappingTest.LocalDateTimeVO</class-b>
+        <field>
+            <a key="key" date-format="yyyy-MM-dd'T'HH:mm:ss">this</a>
+            <b>result</b>
+        </field>
+    </mapping>
+
+    <mapping>
+        <class-a>java.util.HashMap</class-a>
+        <class-b>org.dozer.functional_tests.LocalDateTimeMappingTest.LocalDateVO</class-b>
+        <field>
+            <a key="key" date-format="yyyy-MM-dd">this</a>
+            <b>result</b>
+        </field>
+    </mapping>
+
+    <mapping>
+        <class-a>java.util.HashMap</class-a>
+        <class-b>org.dozer.functional_tests.ZonedDateTimeMappingTest.ZonedDateTimeVO</class-b>
+        <field>
+            <a key="key" date-format="yyyy-MM-dd'T'HH:mm:ssZZZZZ'['VV']'">this</a>
+            <b>result</b>
+        </field>
+    </mapping>
+
+</mappings>


### PR DESCRIPTION
## Issue link
        #172 Java 8 date and time support.

## Purpose
Support Java 8 date and time automated mapping [JSR-310](https://jcp.org/en/jsr/detail?id=310). Converters added for:
* `LocalDate`
* `LocalDateTime`
* `OffsetDateTime`
* `ZonedDateTime`
* `Instant`

Added conversion between types above and
* to and from `String`
* to and from `Date`

## Open Questions and Pre-Merge TODOs
- [x] Issue created
- [ ] Unit tests pass
- [ ] Documentation updated
- [ ] Travis build passed
