### PR TITLE
#530: "MapId" field is now accessible from mapping metadata.

### DIFF
--- a/core/src/main/java/org/dozer/metadata/DozerFieldMappingMetadata.java
+++ b/core/src/main/java/org/dozer/metadata/DozerFieldMappingMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2017 Dozer Project
+ * Copyright 2005-2018 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -78,4 +78,8 @@ public final class DozerFieldMappingMetadata implements FieldMappingMetadata {
         return fieldMap.getCustomConverter();
     }
 
+    @Override
+    public String getMapId() {
+        return fieldMap.getMapId();
+    }
 }

--- a/core/src/main/java/org/dozer/metadata/FieldMappingMetadata.java
+++ b/core/src/main/java/org/dozer/metadata/FieldMappingMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2017 Dozer Project
+ * Copyright 2005-2018 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -81,5 +81,13 @@ public interface FieldMappingMetadata {
      * @return The name of the custom converter class as a string.
      */
     String getCustomConverter();
+
+    /**
+     * Returns the map id of this mapping definition used for contextual mapping selection.
+     *
+     * @return The identifier as a string.
+     */
+    String getMapId();
+
     
 }

--- a/core/src/test/java/org/dozer/functional_tests/MetadataMapIdFieldTest.java
+++ b/core/src/test/java/org/dozer/functional_tests/MetadataMapIdFieldTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2005-2018 Dozer Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dozer.functional_tests;
+
+import org.dozer.Mapper;
+import org.dozer.metadata.ClassMappingMetadata;
+import org.dozer.metadata.FieldMappingMetadata;
+import org.dozer.metadata.MappingMetadata;
+import org.junit.Before;
+import org.junit.Test;
+
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class MetadataMapIdFieldTest
+        extends AbstractFunctionalTest {
+
+    private static final String CUSTOM_FIELD_MAPPING_ID = "field-map-id";
+
+    private static final String MAPPING_FILE = "mappings/metadataMapIdTest.xml";
+    private static final String SOURCE = "org.dozer.vo.metadata.ClassA";
+    private static final String DEST = "org.dozer.vo.metadata.ClassB";
+    private static final String SOURCE_FIELD_1 = "customFieldA";
+    private static final String SOURCE_FIELD_2 = "classC";
+
+    private MappingMetadata mapMetadata;
+
+    @Before
+    public void setup() {
+        Mapper beanMapper = getMapper(MAPPING_FILE);
+        mapMetadata = beanMapper.getMappingMetadata();
+    }
+
+    @Test
+    public void testMapIdForFieldMap() {
+
+        ClassMappingMetadata mapping = mapMetadata.getClassMappingByName(SOURCE, DEST);
+
+        FieldMappingMetadata fieldMapping = mapping.getFieldMappingBySource(SOURCE_FIELD_1);
+        assertEquals(fieldMapping.getMapId(), CUSTOM_FIELD_MAPPING_ID);
+
+        fieldMapping = mapping.getFieldMappingBySource(SOURCE_FIELD_2);
+        assertNull("MapId should be null", fieldMapping.getMapId());
+    }
+}

--- a/core/src/test/resources/mappings/metadataMapIdTest.xml
+++ b/core/src/test/resources/mappings/metadataMapIdTest.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2005-2018 Dozer Project
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<mappings xmlns="http://dozermapper.github.io/schema/bean-mapping"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://dozermapper.github.io/schema/bean-mapping http://dozermapper.github.io/schema/bean-mapping.xsd">
+
+    <mapping>
+        <class-a>org.dozer.vo.metadata.ClassA</class-a>
+        <class-b>org.dozer.vo.metadata.ClassB</class-b>
+        <field map-id="field-map-id">
+            <a>customFieldA</a>
+            <b>customFieldB</b>
+        </field>
+        <field>
+            <a>classC</a>
+            <b>classD</b>
+        </field>
+    </mapping>
+
+</mappings>


### PR DESCRIPTION
#530 

## Purpose
Fixes access to `mapId` field in field mapping metadata.