### PR TITLE
#550 Fall back to synthetic property getter/setter if none other avai…

### DIFF
--- a/core/src/main/java/com/github/dozermapper/core/util/ReflectionUtils.java
+++ b/core/src/main/java/com/github/dozermapper/core/util/ReflectionUtils.java
@@ -109,8 +109,8 @@ public final class ReflectionUtils {
             String baseName = Character.toUpperCase(propertyName.charAt(0)) + propertyName.substring(1);
             String setMethodName = "set" + baseName;
             String getMethodName = "get" + baseName;
-            Method getMethod = findNonSyntheticMethod(getMethodName, clazz);
-            Method setMethod = findNonSyntheticMethod(setMethodName, clazz);
+            Method getMethod = findPreferablyNonSyntheticMethod(getMethodName, clazz);
+            Method setMethod = findPreferablyNonSyntheticMethod(setMethodName, clazz);
             try {
                 return new PropertyDescriptor(propertyName, getMethod, setMethod);
             } catch (IntrospectionException e) {
@@ -120,14 +120,19 @@ public final class ReflectionUtils {
         return descriptor;
     }
 
-    private static Method findNonSyntheticMethod(String methodName, Class<?> clazz) {
+    private static Method findPreferablyNonSyntheticMethod(String methodName, Class<?> clazz) {
         Method[] methods = clazz.getMethods();
+        Method syntheticMethod = null;
         for (Method method : methods) {
-            if (method.getName().equals(methodName) && !method.isBridge() && !method.isSynthetic()) {
-                return method;
+            if (method.getName().equals(methodName)) {
+                if (!method.isBridge() && !method.isSynthetic()) {
+                    return method;
+                } else {
+                    syntheticMethod = method;
+                }
             }
         }
-        return null;
+        return syntheticMethod;
     }
 
     public static DeepHierarchyElement[] getDeepFieldHierarchy(Class<?> parentClass, String field,

--- a/core/src/test/java/com/github/dozermapper/core/util/ReflectionUtilsTest.java
+++ b/core/src/test/java/com/github/dozermapper/core/util/ReflectionUtilsTest.java
@@ -197,6 +197,12 @@ public class ReflectionUtilsTest extends AbstractDozerTest {
         assertEquals("java.util.Map", clazz.getCanonicalName());
     }
 
+    @Test
+    public void shouldDetermineReadMethodForSyntheticOnlyMethod() throws Exception {
+        PropertyDescriptor propertyDescriptor = ReflectionUtils.findPropertyDescriptor(ListHolderWrapperImpl.class, "list", null);
+        assertNotNull(propertyDescriptor.getReadMethod());
+    }
+
     public class Y implements HasX<ClassInheritsClassX> {
         private ClassInheritsClassX x;
 
@@ -254,6 +260,33 @@ public class ReflectionUtilsTest extends AbstractDozerTest {
 
     private interface TestIF2 {
         Integer getB();
+    }
+
+    public class ListHolderWrapperImpl<T> extends AbstractListHolder<T> implements ListHolderWrapper<T> {
+        public ListHolderWrapperImpl(List<T> content) {
+            super(content);
+        }
+    }
+
+    abstract class AbstractListHolder<T> implements ListHolder<T> {
+        private List<T> list;
+
+        AbstractListHolder(List<T> list) {
+            this.list = list;
+        }
+
+        @Override
+        public List<T> getList() {
+            return list;
+        }
+    }
+
+    interface ListHolder<T> {
+        List<T> getList();
+    }
+
+    interface ListHolderWrapper<T> extends ListHolder<T> {
+
     }
 
 }


### PR DESCRIPTION
## Issue link
#550 `ReflectionUtil.findNonSyntheticMethod` failing for non-generics methods

## Purpose
Fix #550

## Approach
Falling back to synthetic method if no non-synthetic method available

## Open Questions and Pre-Merge TODOs
- [ ] Issue created
- [ ] Unit tests pass
- [ ] Documentation updated
- [ ] Travis build passed
