### PR TITLE
Polishing code on dozer-spring-boot-autoconfigure

### DIFF
--- a/dozer-integrations/dozer-spring-support/dozer-spring-boot-autoconfigure/src/main/java/com/github/dozermapper/springboot/autoconfigure/DozerAutoConfiguration.java
+++ b/dozer-integrations/dozer-spring-support/dozer-spring-boot-autoconfigure/src/main/java/com/github/dozermapper/springboot/autoconfigure/DozerAutoConfiguration.java
@@ -20,7 +20,6 @@ import java.io.IOException;
 import com.github.dozermapper.core.Mapper;
 import com.github.dozermapper.spring.DozerBeanMapperFactoryBean;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -43,7 +42,6 @@ public class DozerAutoConfiguration {
      *
      * @param configurationProperties properties
      */
-    @Autowired
     public DozerAutoConfiguration(DozerConfigurationProperties configurationProperties) {
         this.configurationProperties = configurationProperties;
     }


### PR DESCRIPTION
## Purpose
I've polished some codes on dozer-spring-boot-autoconfigure.

* Remove `@Autowired` from constructor

## Open Questions and Pre-Merge TODOs
- [ ] Issue created
- [x] Unit tests pass
- [ ] Documentation updated
- [x] Travis build passed
