### PR TITLE
Add spring-boot-starter in dozer-spring-boot-starter

### DIFF
--- a/dozer-integrations/dozer-spring-support/dozer-spring-boot-starter/pom.xml
+++ b/dozer-integrations/dozer-spring-support/dozer-spring-boot-starter/pom.xml
@@ -31,6 +31,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.github.dozermapper</groupId>
             <artifactId>dozer-core</artifactId>
         </dependency>


### PR DESCRIPTION
## Purpose
I think the current dozer-spring-boot-start does not consists the starter project of spring-boot because it not include the spring-boot-starter.

**NOTE:** All official starters include the spring-boot-starter.

## Approach
I will propose to add the spring-boot-starter as dependency artifact.

## Open Questions and Pre-Merge TODOs
- [ ] Issue created
- [x] Unit tests pass
- [ ] Documentation updated
- [x] Travis build passed
