### PR TITLE
[662] Polish springboot support

### DIFF
--- a/dozer-integrations/dozer-spring-support/dozer-spring-boot-autoconfigure/pom.xml
+++ b/dozer-integrations/dozer-spring-support/dozer-spring-boot-autoconfigure/pom.xml
@@ -33,6 +33,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-autoconfigure</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.github.dozermapper</groupId>
             <artifactId>dozer-core</artifactId>
             <optional>true</optional>
@@ -46,17 +51,7 @@
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-autoconfigure</artifactId>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-configuration-processor</artifactId>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-core</artifactId>
             <optional>true</optional>
         </dependency>
         <dependency>

--- a/dozer-integrations/dozer-spring-support/dozer-spring-boot-autoconfigure/src/main/java/com/github/dozermapper/springboot/autoconfigure/DozerAutoConfiguration.java
+++ b/dozer-integrations/dozer-spring-support/dozer-spring-boot-autoconfigure/src/main/java/com/github/dozermapper/springboot/autoconfigure/DozerAutoConfiguration.java
@@ -32,18 +32,18 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 @ConditionalOnClass({DozerBeanMapperFactoryBean.class, Mapper.class})
 @ConditionalOnMissingBean(Mapper.class)
-@EnableConfigurationProperties(DozerConfigurationProperties.class)
+@EnableConfigurationProperties(DozerProperties.class)
 public class DozerAutoConfiguration {
 
-    private final DozerConfigurationProperties configurationProperties;
+    private final DozerProperties properties;
 
     /**
      * Constructor for creating auto configuration.
      *
-     * @param configurationProperties properties
+     * @param properties properties
      */
-    public DozerAutoConfiguration(DozerConfigurationProperties configurationProperties) {
-        this.configurationProperties = configurationProperties;
+    public DozerAutoConfiguration(DozerProperties properties) {
+        this.properties = properties;
     }
 
     /**
@@ -55,7 +55,7 @@ public class DozerAutoConfiguration {
     @Bean
     public DozerBeanMapperFactoryBean dozerMapper() throws IOException {
         DozerBeanMapperFactoryBean factoryBean = new DozerBeanMapperFactoryBean();
-        factoryBean.setMappingFiles(configurationProperties.getMappingFiles());
+        factoryBean.setMappingFiles(properties.getMappingFiles());
         return factoryBean;
     }
 }

--- a/dozer-integrations/dozer-spring-support/dozer-spring-boot-autoconfigure/src/main/java/com/github/dozermapper/springboot/autoconfigure/DozerProperties.java
+++ b/dozer-integrations/dozer-spring-support/dozer-spring-boot-autoconfigure/src/main/java/com/github/dozermapper/springboot/autoconfigure/DozerProperties.java
@@ -21,14 +21,14 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.core.io.Resource;
 
 /**
- * Dozer configuration properties.
+ * Configuration properties for Dozer.
  */
 @ConfigurationProperties(prefix = "dozer")
-public class DozerConfigurationProperties {
+public class DozerProperties {
 
     /**
      * Mapping files configuration.
-     * For example <code>classpath:*.dozer.xml</code>.
+     * For example "classpath:*.dozer.xml".
      */
     private Resource[] mappingFiles = new Resource[] {};
 
@@ -47,7 +47,7 @@ public class DozerConfigurationProperties {
      * @param mappingFiles dozer mapping files
      * @return dozer properties
      */
-    public DozerConfigurationProperties setMappingFiles(Resource[] mappingFiles) {
+    public DozerProperties setMappingFiles(Resource[] mappingFiles) {
         this.mappingFiles = Arrays.copyOf(mappingFiles, mappingFiles.length);
         return this;
     }

--- a/dozer-integrations/dozer-spring-support/dozer-spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
+++ b/dozer-integrations/dozer-spring-support/dozer-spring-boot-autoconfigure/src/main/resources/META-INF/spring.factories
@@ -15,4 +15,4 @@
 #
 
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-  com.github.dozermapper.springboot.autoconfigure.DozerAutoConfiguration
+com.github.dozermapper.springboot.autoconfigure.DozerAutoConfiguration

--- a/dozer-integrations/dozer-spring-support/dozer-spring-boot-autoconfigure/src/test/java/com/github/dozermaper/springboot/autoconfigure/DozerAutoConfigurationTests.java
+++ b/dozer-integrations/dozer-spring-support/dozer-spring-boot-autoconfigure/src/test/java/com/github/dozermaper/springboot/autoconfigure/DozerAutoConfigurationTests.java
@@ -36,7 +36,10 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-public class AutoConfigurationTests {
+/**
+ * Tests for {@link DozerAutoConfiguration}.
+ */
+public class DozerAutoConfigurationTests {
 
     @Test
     public void testDefaultMapperCreated() {


### PR DESCRIPTION
This PR polishes the Spring Boot auto-configuration:

* Harmonize name of `ConfigurationProperties`
* Clean dependencies (an auto-configuration module should have a dependency on spring boot autoconfigure as it is its main purpose)
* `@ConditionalOnMissingBean` should be put in the `@Bean` method that it references to (if any) rather than at class level.

## Open Questions and Pre-Merge TODOs
- [ ] Issue created
- [ ] Unit tests pass
- [ ] Documentation updated
- [ ] Travis build passed
