### PR TITLE
Upgraded asm dependancy for spifly to v6 for java9

### DIFF
--- a/tests/dozer-osgi-tests/pom.xml
+++ b/tests/dozer-osgi-tests/pom.xml
@@ -149,6 +149,18 @@
             <groupId>org.apache.aries.spifly</groupId>
             <artifactId>org.apache.aries.spifly.dynamic.bundle</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.ow2.asm</groupId>
+                    <artifactId>asm-debug-all</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.ow2.asm</groupId>
+            <artifactId>asm-all</artifactId>
+            <version>6.0_BETA</version>
+            <scope>test</scope>
         </dependency>
 
         <!-- Spring OSGi -->

--- a/tests/dozer-osgi-tests/src/test/java/com/github/dozermapper/osgitests/Proto3KarafContainerTest.java
+++ b/tests/dozer-osgi-tests/src/test/java/com/github/dozermapper/osgitests/Proto3KarafContainerTest.java
@@ -53,7 +53,7 @@ public class Proto3KarafContainerTest extends CoreKarafContainerTest {
                 // ServiceLoader
                 localBundle("org.apache.aries.spifly.dynamic.bundle.link"),
                 localBundle("org.apache.aries.util.link"),
-                localBundle("org.objectweb.asm.all.debug.link"),
+                localBundle("org.objectweb.asm.all.link"),
 
                 // Bundles
                 BundleOptions.optionalBundles(),


### PR DESCRIPTION
- https://github.com/DozerMapper/dozer/issues/580