### PR TITLE
Fix collection item duplication (#667)

### DIFF
--- a/core/src/main/java/com/github/dozermapper/core/classmap/ClassMapBuilder.java
+++ b/core/src/main/java/com/github/dozermapper/core/classmap/ClassMapBuilder.java
@@ -408,7 +408,8 @@ public final class ClassMapBuilder {
                     if (mapping != null) {
                         String propertyName = property.getName();
                         String pairName = mapping.value().trim();
-                        if (requireMapping(mapping, classMap.getDestClassToMap(), propertyName, pairName)) {
+                        if (requireMapping(mapping, classMap.getDestClassToMap(), propertyName, pairName)
+                                && classMap.getFieldMapUsingSrc(propertyName) == null) {
                             GeneratorUtils.addGenericMapping(MappingType.GETTER_TO_SETTER, classMap, configuration,
                                                              propertyName, pairName.isEmpty() ? propertyName : pairName, beanContainer, destBeanCreator, propertyDescriptorFactory);
                         }


### PR DESCRIPTION
## Purpose
Fix collection item duplication (#667)

## Approach
This change adds a validation on **AnnotationPropertiesGenerator** to ensure that a field will not be added to the ClassMap object twice.

## Open Questions and Pre-Merge TODOs
- [x] Issue created
- [x] Unit tests pass
- [ ] Documentation updated
- [ ] Travis build passed
