### PR TITLE
Fixing osgi import issue

### DIFF
--- a/plugins-parent/pom.xml
+++ b/plugins-parent/pom.xml
@@ -72,7 +72,7 @@
         <osgi.Bundle-Activator/>
         <osgi.defaults.Import-Package>
             !${osgi.Export-Package},
-            com.github.dozermapper.*;${osgi.Import-Package.version}
+            com.github.dozermapper.*;${osgi.Import-Package.version},
             org.osgi.framework;version="[1.7,2)";resolution:=optional
         </osgi.defaults.Import-Package>
         <osgi.additional.Import-Package/>


### PR DESCRIPTION
Currently it is not possible to deploy Dozer to JBoss Fuse 6.2 because Dozer bundle imports OSGi framework version 1.8, while Fuse has an older version.

We have an explicit configuration for the bundle plugin to import framework version 1.7 with optional resolution. But due to a typo, it is ignored and classpath dependency version is used instead during the bundle descriptor generation.

This pull request fixes the issue so that our configuration is applied to the final bundle descriptor.

As this blocks our project from migration to Dozer 6, it would be great to release a new version after this fix is merged. 