### PR TITLE
[ISSUE: 696] fixes nested proto3 messages ClassNotFoundException

### DIFF
--- a/dozer-integrations/dozer-proto3/src/test/java/com/github/dozermapper/protobuf/functional_tests/ProtoBeansMultipleFilesMappingTest.java
+++ b/dozer-integrations/dozer-proto3/src/test/java/com/github/dozermapper/protobuf/functional_tests/ProtoBeansMultipleFilesMappingTest.java
@@ -17,8 +17,12 @@ package com.github.dozermapper.protobuf.functional_tests;
 
 import com.github.dozermapper.core.DozerBeanMapperBuilder;
 import com.github.dozermapper.core.Mapper;
+import com.github.dozermapper.protobuf.vo.proto.TestContainerObject;
 import com.github.dozermapper.protobuf.vo.proto.NestedObject;
 import com.github.dozermapper.protobuf.vo.proto.TestObject;
+import com.github.dozermapper.protobuf.vo.proto.TestContainerObject.TestContainedEnum;
+import com.github.dozermapper.protobuf.vo.protomultiple.ContainerObject;
+import com.github.dozermapper.protobuf.vo.protomultiple.ContainerObject.ContainedEnum;
 import com.github.dozermapper.protobuf.vo.protomultiple.SimpleProtoTestObject;
 
 import org.junit.BeforeClass;
@@ -67,5 +71,38 @@ public class ProtoBeansMultipleFilesMappingTest {
         assertNotNull(result.getNested());
         assertNotNull(result.getNested().getOne());
         assertEquals(simpleProtoTestObject.getNested().getOne(), result.getNested().getOne());
+    }
+    
+    @Test
+    public void canNestedObjectToProto() {
+        TestContainerObject containerObject = new TestContainerObject();
+        containerObject.setEnum1(TestContainedEnum.VALUE2);
+        containerObject.setObj1(new TestContainerObject.TestContainedObject());
+        containerObject.getObj1().setC1("ABC");
+        
+        ContainerObject result = mapper.map(containerObject, ContainerObject.class);
+        assertNotNull(result);
+        assertNotNull(result.getEnum1());
+        assertNotNull(result.getObj1());
+        assertNotNull(result.getObj1().getC1());
+        assertEquals(containerObject.getObj1().getC1(), result.getObj1().getC1());
+        assertEquals(containerObject.getEnum1().name(), result.getEnum1().name());
+    }
+
+    @Test
+    public void canNestedObjectFromProto() {
+        ContainerObject.Builder containerBuiler = ContainerObject.newBuilder();
+        containerBuiler.setEnum1(ContainedEnum.VALUE2);
+        containerBuiler.setObj1(ContainerObject.ContainedObject.newBuilder().setC1("ABC").build());
+        ContainerObject container = containerBuiler.build();
+        TestContainerObject result = mapper.map(container, TestContainerObject.class);
+        assertNotNull(result);
+        assertNotNull(result.getEnum1());
+        assertNotNull(result.getObj1());
+        assertNotNull(result.getObj1().getC1());
+        assertEquals(container.getObj1().getC1(), result.getObj1().getC1());
+        assertEquals(container.getEnum1().name(), result.getEnum1().name());
+        
+        
     }
 }

--- a/dozer-integrations/dozer-proto3/src/test/java/com/github/dozermapper/protobuf/vo/proto/TestContainerObject.java
+++ b/dozer-integrations/dozer-proto3/src/test/java/com/github/dozermapper/protobuf/vo/proto/TestContainerObject.java
@@ -1,0 +1,45 @@
+package com.github.dozermapper.protobuf.vo.proto;
+
+public class TestContainerObject {
+    public enum TestContainedEnum {
+        VALUE1, VALUE2;
+    }
+    
+    public static class TestContainedObject{
+        private String c1;
+        
+        public TestContainedObject() {
+            
+        }
+        
+        public String getC1() {
+            return c1;
+        }
+        
+        public void setC1(String c1) {
+            this.c1 = c1;
+        }
+    }
+    
+    private TestContainedObject obj1;
+    private TestContainedEnum enum1;
+    
+    public TestContainerObject() {
+    }
+    
+    public TestContainedEnum getEnum1() {
+        return enum1;
+    }
+    
+    public TestContainedObject getObj1() {
+        return obj1;
+    }
+    
+    public void setEnum1(TestContainedEnum enum1) {
+        this.enum1 = enum1;
+    }
+    
+    public void setObj1(TestContainedObject obj1) {
+        this.obj1 = obj1;
+    }
+}

--- a/dozer-integrations/dozer-proto3/src/test/java/com/github/dozermapper/protobuf/vo/proto/TestContainerObject.java
+++ b/dozer-integrations/dozer-proto3/src/test/java/com/github/dozermapper/protobuf/vo/proto/TestContainerObject.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2005-2018 Dozer Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.github.dozermapper.protobuf.vo.proto;
 
 public class TestContainerObject {

--- a/dozer-integrations/dozer-proto3/src/test/proto/ProtoTestObjectsMultipleFiles.proto
+++ b/dozer-integrations/dozer-proto3/src/test/proto/ProtoTestObjectsMultipleFiles.proto
@@ -25,3 +25,18 @@ message TestObject {
 message SimpleProtoTestObject {
     TestObject nested = 1;
 }
+
+message ContainerObject {
+
+    enum ContainedEnum {
+		VALUE1 = 0;
+		VALUE2 = 1;
+    }
+	
+    message ContainedObject {
+        string c1 = 1;
+    }
+
+    ContainedObject obj1 = 1;
+    ContainedEnum enum1 = 2;
+}

--- a/dozer-integrations/dozer-proto3/src/test/resources/mappings/protoBeansMapping.xml
+++ b/dozer-integrations/dozer-proto3/src/test/resources/mappings/protoBeansMapping.xml
@@ -87,4 +87,26 @@
         </field>
     </mapping>
 
+    <mapping wildcard="false">
+        <class-a>com.github.dozermapper.protobuf.vo.proto.TestContainerObject.TestContainedObject</class-a>
+        <class-b>com.github.dozermapper.protobuf.vo.protomultiple.ContainerObject.ContainedObject</class-b>
+        <field>
+            <a>c1</a>
+            <b>c1</b>
+        </field>
+    </mapping>
+
+    <mapping wildcard="false">
+        <class-a>com.github.dozermapper.protobuf.vo.proto.TestContainerObject</class-a>
+        <class-b>com.github.dozermapper.protobuf.vo.protomultiple.ContainerObject</class-b>
+        <field>
+            <a>obj1</a>
+            <b>obj1</b>
+        </field>
+        <field>
+            <a>enum1</a>
+            <b>enum1</b>
+        </field>
+    </mapping>
+
 </mappings>


### PR DESCRIPTION
## Issue link
        [ISSUE: 696] fixes nested proto3 messages ClassNotFoundException

## Purpose

This fixes #696, which does not take into account nested protobuf message types while builing the message Java class full name, causing ClassNotFoundException

## Approach

`com.github.dozermapper.protobuf.util.ProtoUtils.getFullyQualifiedClassName(Descriptor)` updated to use `com.google.protobuf.Descriptors.Descriptor.getContainingType()` to read the message or enum ancestor container names and add them to the derived class full name. 

## Open Questions and Pre-Merge TODOs
- [  ] Issue created
- [ ] Unit tests pass
- [ ] Documentation updated
- [ ] Travis build passed
