### PR TITLE
Switched to OpenJDK due to license change

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,16 +9,18 @@ env:
 language: java
 matrix:
   include:
-  - jdk: oraclejdk8
+  - jdk: openjdk8
     env: SHOULD_DEPLOY=true
-  - jdk: oraclejdk9
+  - jdk: oraclejdk8
     env: SHOULD_DEPLOY=false
-  - jdk: oraclejdk10
+  - jdk: openjdk9
     env: SHOULD_DEPLOY=false
-  - jdk: oraclejdk11
+  - jdk: openjdk10
+    env: SHOULD_DEPLOY=false
+  - jdk: openjdk11
     env: SHOULD_DEPLOY=false
   allow_failures:
-  - jdk: oraclejdk11
+  - jdk: openjdk11
 before_install:
 - bash .travis/deploy-codesigning.sh
 install:

--- a/core/src/main/java/com/github/dozermapper/core/util/DozerConstants.java
+++ b/core/src/main/java/com/github/dozermapper/core/util/DozerConstants.java
@@ -28,7 +28,7 @@ public final class DozerConstants {
     private DozerConstants() {
     }
 
-    public static final String CURRENT_VERSION = "6.4.1";
+    public static final String CURRENT_VERSION = "6.5.0-SNAPSHOT";
 
     public static final boolean DEFAULT_WILDCARD_POLICY = true;
     public static final boolean DEFAULT_WILDCARD_CASE_INSENSITIVE_POLICY = false;


### PR DESCRIPTION
Due to Oracle changing the license for Oracle JDK 11, switching to OpenJDK
- https://blog.joda.org/2018/09/do-not-fall-into-oracles-java-11-trap.html