### PR TITLE
Updated java modules version range for pax exam to be only for 9 and 10

### DIFF
--- a/tests/dozer-osgi-tests/src/test/java/com/github/dozermapper/osgitests/support/PaxExamTestSupport.java
+++ b/tests/dozer-osgi-tests/src/test/java/com/github/dozermapper/osgitests/support/PaxExamTestSupport.java
@@ -117,7 +117,7 @@ public abstract class PaxExamTestSupport {
     }
 
     private Option getJavaModuleOptions() {
-        if (JavaVersionUtil.getMajorVersion() >= 9) {
+        if (JavaVersionUtil.getMajorVersion() >= 9 && JavaVersionUtil.getMajorVersion() <= 10) {
             return composite(
                     vmOption("--add-opens"),
                     vmOption("java.base/java.security=ALL-UNNAMED"),


### PR DESCRIPTION
- https://github.com/DozerMapper/dozer/issues/712