### PR TITLE
Map enums by name instead of using toString() (#52)

### DIFF
--- a/core/src/main/java/com/github/dozermapper/core/converters/EnumConverter.java
+++ b/core/src/main/java/com/github/dozermapper/core/converters/EnumConverter.java
@@ -39,7 +39,9 @@ public class EnumConverter implements Converter {
             } else if ((srcObj.getClass().equals(Integer.class)) || (srcObj.getClass().equals(Integer.TYPE))) {
                 return EnumUtils.getEnumList(destClass).get((Integer)srcObj);
             } else if ((srcObj.getClass().equals(Long.class)) || (srcObj.getClass().equals(Long.TYPE))) {
-                return EnumUtils.getEnumList(destClass).get(((Long)srcObj).intValue());
+                return EnumUtils.getEnumList(destClass).get(((Long) srcObj).intValue());
+            } else if (Enum.class.isAssignableFrom(srcObj.getClass())) {
+                return Enum.valueOf(destClass, ((Enum)srcObj).name());
             } else {
                 return Enum.valueOf(destClass, srcObj.toString());
             }

--- a/core/src/test/java/com/github/dozermapper/core/converters/EnumConverterTest.java
+++ b/core/src/test/java/com/github/dozermapper/core/converters/EnumConverterTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2005-2018 Dozer Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.dozermapper.core.converters;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class EnumConverterTest {
+    @Test
+    public void canConvertEnumWithOverriddenToStringSameType() {
+        assertEquals(Type.ONE, new EnumConverter().convert(Type.class, Type.ONE));
+        assertEquals(Type.TWO, new EnumConverter().convert(Type.class, Type.TWO));
+    }
+
+    @Test
+    public void canConvertEnumWithOverriddenToStringDifferentTypes() {
+        assertEquals(AlsoType.ONE, new EnumConverter().convert(AlsoType.class, Type.ONE));
+        assertEquals(AlsoType.TWO, new EnumConverter().convert(AlsoType.class, Type.TWO));
+    }
+
+    public enum Type {
+        ONE,
+        TWO;
+
+        @Override
+        public String toString() {
+            switch (this) {
+                case ONE:
+                    return "One (1)";
+                case TWO:
+                    return "Two (2)";
+                default:
+                    return "UNKNOWN";
+            }
+        }
+    }
+
+    public enum AlsoType {
+        ONE,
+        TWO;
+
+        @Override
+        public String toString() {
+            switch (this) {
+                case ONE:
+                    return "(1)";
+                case TWO:
+                    return "(2)";
+                default:
+                    return "?";
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Issue link

        [ISSUE: 52] Map with name() and valueOf(...) for Enums in EnumConverter

## Purpose
Allow enums to map correctly even in the case of overriden toString methods

## Approach
Implement special case EnumConverter ckass when source object is enum, using Enum::name. 

## Open Questions and Pre-Merge TODOs
- [ ] Issue created
- [ ] Unit tests pass
- [ ] Documentation updated
- [ ] Travis build passed
