### PR TITLE
Introduced the @Excluding annotation

### DIFF
--- a/core/src/main/java/com/github/dozermapper/core/Excluding.java
+++ b/core/src/main/java/com/github/dozermapper/core/Excluding.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2005-2018 Dozer Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.dozermapper.core;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import com.github.dozermapper.core.builder.model.jaxb.Type;
+import static com.github.dozermapper.core.builder.model.jaxb.Type.BI_DIRECTIONAL;
+
+/**
+ * Defines mapping exclusions on property or field levels. If property level is
+ * considered this annotation should be put on valid bean property getter
+ * method.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.FIELD, ElementType.METHOD})
+public @interface Excluding {
+
+    Type type() default BI_DIRECTIONAL;
+
+}

--- a/core/src/main/java/com/github/dozermapper/core/classmap/ClassMapBuilder.java
+++ b/core/src/main/java/com/github/dozermapper/core/classmap/ClassMapBuilder.java
@@ -24,8 +24,10 @@ import java.util.List;
 import java.util.Map.Entry;
 import java.util.Set;
 
+import com.github.dozermapper.core.Excluding;
 import com.github.dozermapper.core.Mapping;
 import com.github.dozermapper.core.OptionValue;
+import com.github.dozermapper.core.builder.model.jaxb.Type;
 import com.github.dozermapper.core.classmap.generator.BeanMappingGenerator;
 import com.github.dozermapper.core.classmap.generator.ClassLevelFieldMappingGenerator;
 import com.github.dozermapper.core.classmap.generator.GeneratorUtils;
@@ -404,9 +406,15 @@ public final class ClassMapBuilder {
             for (PropertyDescriptor property : srcProperties) {
                 Method readMethod = property.getReadMethod();
                 if (readMethod != null) {
+                    String propertyName = property.getName();
+                    Excluding excluding = readMethod.getAnnotation(Excluding.class);
+                    if (excluding != null) {
+                        GeneratorUtils.addMapping(MappingType.GETTER_TO_SETTER, classMap, configuration,
+                                propertyName, propertyName,
+                                beanContainer, destBeanCreator, propertyDescriptorFactory, excluding);
+                    }
                     Mapping mapping = readMethod.getAnnotation(Mapping.class);
                     if (mapping != null) {
-                        String propertyName = property.getName();
                         String pairName = mapping.value().trim();
                         if (requireMapping(mapping, classMap.getDestClassToMap(), propertyName, pairName)
                                 && classMap.getFieldMapUsingSrc(propertyName) == null) {
@@ -423,9 +431,15 @@ public final class ClassMapBuilder {
             for (PropertyDescriptor property : destProperties) {
                 Method readMethod = property.getReadMethod();
                 if (readMethod != null) {
+                    String propertyName = property.getName();
+                    Excluding excluding = readMethod.getAnnotation(Excluding.class);
+                    if (excluding != null && excluding.type() == Type.BI_DIRECTIONAL) {
+                        GeneratorUtils.addMapping(MappingType.GETTER_TO_SETTER, classMap, configuration,
+                                propertyName, propertyName,
+                                beanContainer, destBeanCreator, propertyDescriptorFactory, excluding);
+                    }
                     Mapping mapping = readMethod.getAnnotation(Mapping.class);
                     if (mapping != null) {
-                        String propertyName = property.getName();
                         String pairName = mapping.value().trim();
                         if (requireMapping(mapping, classMap.getSrcClassToMap(), propertyName, pairName)) {
                             GeneratorUtils.addGenericMapping(MappingType.GETTER_TO_SETTER, classMap, configuration,
@@ -459,8 +473,14 @@ public final class ClassMapBuilder {
             Class<?> srcType = classMap.getSrcClassToMap();
             do {
                 for (Field field : srcType.getDeclaredFields()) {
-                    Mapping mapping = field.getAnnotation(Mapping.class);
                     String fieldName = field.getName();
+                    Excluding excluding = field.getAnnotation(Excluding.class);
+                    if (excluding != null) {
+                        GeneratorUtils.addMapping(MappingType.GETTER_TO_SETTER, classMap, configuration,
+                                fieldName, fieldName,
+                                beanContainer, destBeanCreator, propertyDescriptorFactory, excluding);
+                    }
+                    Mapping mapping = field.getAnnotation(Mapping.class);
                     if (mapping != null) {
                         String pairName = mapping.value().trim();
                         if (requireMapping(mapping, classMap.getDestClassToMap(), fieldName, pairName)) {
@@ -476,8 +496,14 @@ public final class ClassMapBuilder {
             Class<?> destType = classMap.getDestClassToMap();
             do {
                 for (Field field : destType.getDeclaredFields()) {
-                    Mapping mapping = field.getAnnotation(Mapping.class);
                     String fieldName = field.getName();
+                    Excluding excluding = field.getAnnotation(Excluding.class);
+                    if (excluding != null && excluding.type() == Type.BI_DIRECTIONAL) {
+                        GeneratorUtils.addMapping(MappingType.GETTER_TO_SETTER, classMap, configuration,
+                                fieldName, fieldName,
+                                beanContainer, destBeanCreator, propertyDescriptorFactory, excluding);
+                    }
+                    Mapping mapping = field.getAnnotation(Mapping.class);
                     if (mapping != null) {
                         String pairName = mapping.value().trim();
                         if (requireMapping(mapping, classMap.getSrcClassToMap(), fieldName, pairName)) {

--- a/core/src/test/java/com/github/dozermapper/core/functional_tests/annotation/AnnotationExcludeFieldTest.java
+++ b/core/src/test/java/com/github/dozermapper/core/functional_tests/annotation/AnnotationExcludeFieldTest.java
@@ -1,0 +1,274 @@
+/*
+ * Copyright 2005-2018 Dozer Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.dozermapper.core.functional_tests.annotation;
+
+import com.github.dozermapper.core.Excluding;
+import com.github.dozermapper.core.Mapping;
+import com.github.dozermapper.core.builder.model.jaxb.Type;
+import com.github.dozermapper.core.functional_tests.AbstractFunctionalTest;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class AnnotationExcludeFieldTest extends AbstractFunctionalTest {
+
+    @Override
+    @Before
+    public void setUp() throws Exception {
+        mapper = getMapper();
+    }
+
+    @Test
+    public void testExcludedField_SimpleLevel() {
+        ZeroB zeroB = newInstance(ZeroB.class);
+        zeroB.setId(Integer.valueOf("10"));
+        ZeroA zeroA = mapper.map(zeroB, ZeroA.class);
+
+        assertNull(zeroA.getId());
+        assertEquals(Integer.valueOf("10"), zeroB.getId());
+    }
+
+    @Test
+    public void testExcludedField_SimpleReverse() {
+        ZeroA zeroA = newInstance(ZeroA.class);
+        zeroA.setId(Integer.valueOf("5"));
+        ZeroB zeroB = mapper.map(zeroA, ZeroB.class);
+
+        assertEquals(Integer.valueOf("5"), zeroA.getId());
+        assertNull(zeroB.getId());
+    }
+
+    @Test
+    public void testExcludedField_OneLevel() {
+        OneB oneB = newInstance(OneB.class);
+        oneB.setId(Integer.valueOf("10"));
+        OneA oneA = mapper.map(oneB, OneA.class);
+
+        assertNull(oneA.getId());
+        assertEquals(Integer.valueOf("10"), oneB.getId());
+    }
+
+    @Test
+    public void testExcludedField_OneLevelReverse() {
+        OneA oneA = newInstance(OneA.class);
+        oneA.setId(Integer.valueOf("5"));
+        OneB oneB = mapper.map(oneA, OneB.class);
+
+        assertEquals(Integer.valueOf("5"), oneA.getId());
+        assertNull(oneB.getId());
+    }
+
+    @Test
+    public void testExcludedField_TwoLevel() {
+        TwoB twoB = new TwoB();
+        twoB.setId(Integer.valueOf("10"));
+        TwoA twoA = mapper.map(twoB, TwoA.class);
+        assertNull(twoA.getId());
+        assertEquals(Integer.valueOf("10"), twoB.getId());
+    }
+
+    @Test
+    public void testExcludedField_TwoLevelReverse() {
+        TwoA twoA = newInstance(TwoA.class);
+        twoA.setId(Integer.valueOf("5"));
+        TwoB twoB = mapper.map(twoA, TwoB.class);
+        assertEquals(Integer.valueOf("5"), twoA.getId());
+        assertNull(twoB.getId());
+    }
+
+    @Test
+    public void testExcludedField() {
+        ZeroA zeroA = new ZeroA();
+        zeroA.field2 = 35;
+        ZeroB zeroB = mapper.map(zeroA, ZeroB.class);
+        assertEquals((Integer) 35, zeroB.field1);
+        assertNull(zeroB.field2);
+    }
+
+    @Test
+    public void testOneWayExclusion() {
+        ZeroA zeroA = new ZeroA();
+        zeroA.field3 = 15;
+        ZeroB zeroB = mapper.map(zeroA, ZeroB.class);
+        assertNull(zeroB.field3);
+        zeroB = new ZeroB();
+        zeroB.field3 = 20;
+        zeroA = mapper.map(zeroB, ZeroA.class);
+        assertEquals((Integer) 20, zeroA.field3);
+    }
+
+    @Test
+    public void testTwoWayExclusion() {
+        ZeroA zeroA = new ZeroA();
+        zeroA.field4 = 15;
+        ZeroB zeroB = mapper.map(zeroA, ZeroB.class);
+        assertNull(zeroB.field4);
+        zeroB = new ZeroB();
+        zeroB.field4 = 20;
+        zeroA = mapper.map(zeroB, ZeroA.class);
+        assertNull(zeroA.field4);
+    }
+
+    @Test
+    public void testTwoWayGetterExclusion() {
+        ZeroA zeroA = new ZeroA();
+        zeroA.field5 = 15;
+        ZeroB zeroB = mapper.map(zeroA, ZeroB.class);
+        assertNull(zeroB.field5);
+        zeroB = new ZeroB();
+        zeroB.field5 = 20;
+        zeroA = mapper.map(zeroB, ZeroA.class);
+        assertNull(zeroA.field5);
+    }
+
+    public static class ZeroA {
+
+        @Excluding
+        private Integer id;
+        @Excluding
+        Integer field1;
+        @Excluding
+        @Mapping("field1")
+        Integer field2;
+        @Excluding(type = Type.ONE_WAY)
+        Integer field3;
+        @Excluding(type = Type.BI_DIRECTIONAL)
+        Integer field4;
+        private Integer field5;
+
+        public Integer getId() {
+            return id;
+        }
+
+        public void setId(Integer id) {
+            this.id = id;
+        }
+
+        public void setField1(Integer field1) {
+            this.field1 = field1;
+        }
+
+        public Integer getField1() {
+            return field1;
+        }
+
+        public Integer getField2() {
+            return field2;
+        }
+
+        public void setField3(Integer field3) {
+            this.field3 = field3;
+        }
+
+        public Integer getField3() {
+            return field3;
+        }
+
+        public void setField4(Integer field4) {
+            this.field4 = field4;
+        }
+
+        public Integer getField4() {
+            return field4;
+        }
+
+        @Excluding
+        public Integer getField5() {
+            return field5;
+        }
+
+        public void setField5(Integer field5) {
+            this.field5 = field5;
+        }
+
+    }
+
+    public static class ZeroB {
+
+        @Excluding
+        private Integer id;
+        Integer field1;
+        Integer field2;
+        Integer field3;
+        Integer field4;
+        Integer field5;
+
+        public Integer getId() {
+            return id;
+        }
+
+        public void setId(Integer id) {
+            this.id = id;
+        }
+
+        public void setField1(Integer field1) {
+            this.field1 = field1;
+        }
+
+        public Integer getField1() {
+            return field1;
+        }
+
+        public void setField2(Integer field2) {
+            this.field2 = field2;
+        }
+
+        public void setField3(Integer field3) {
+            this.field3 = field3;
+        }
+
+        public Integer getField3() {
+            return field3;
+        }
+
+        public void setField4(Integer field4) {
+            this.field4 = field4;
+        }
+
+        public Integer getField4() {
+            return field4;
+        }
+
+        public Integer getField5() {
+            return field5;
+        }
+
+        public void setField5(Integer field5) {
+            this.field5 = field5;
+        }
+
+    }
+
+    public static class OneA extends ZeroA {
+
+    }
+
+    public static class OneB extends ZeroB {
+
+    }
+
+    public static class TwoA extends OneA {
+
+    }
+
+    public static class TwoB extends OneB {
+
+    }
+
+}


### PR DESCRIPTION
Excludes fields from mapping by putting the `@Excluding` annotation on the
field or the field's getter method. This feature is requested in issue 648.

## Issue link
[[ISSUE: 648] can provide filed exclusion annotation?](https://github.com/DozerMapper/dozer/issues/648)

## Purpose
A new annotation is introduced for excluding fields from the default mapping. The new annotation is the `@Excluding` and can be used directly on a field or in a getter method. If a specific mapping is created by using the `@Mapping` annotation, this mapping is not excluded. This means that the `@Excluding` works only to ignore the default mapping where the source and destination fields share the same name.

## Approach
The new `@Excluding` annotation was created.
The `AnnotationPropertiesGenerator` and `AnnotationFieldsGenerator` in `ClassMapBuilder` were modified to check if the new annotation is used. In that case an `ExcludeFieldMap` is added in the `classmap` by using a new method that was created in `GeneratorUtils`.
Finally, the `AnnotationExcludeFieldTest` was created. This tests is a copy of `ExcludeFieldTest` with some modifications and additional tests.

## Open Questions and Pre-Merge TODOs
- [x] Issue created
- [x] Unit tests pass
- [ ] Documentation updated
- [ ] Travis build passed

I would like some feedback regarding the approach of implementing this functionality before updating the documentation. If you think this is ok I'll be happy to update the documentation too. Otherwise, I am willing to work on adjustments if required.