### PR TITLE
Support the customizer interface of DozerBeanMapperBuilder for integrating with Spring DI container

### DIFF
--- a/docs/asciidoc/documentation/springintegration.adoc
+++ b/docs/asciidoc/documentation/springintegration.adoc
@@ -102,6 +102,78 @@ public class DozerConfig {
 }
 ----
 
+==== Using the DozerBeanMapperBuilderCustomizer
+
+Since 6.5.0, We add the `DozerBeanMapperBuilderCustomizer` interface that it customize a builder instance for creating a mapper.
+If you want to customize fully a mapper that create by `DozerBeanMapperFactoryBean` (using the XML namespace or autoconfigure for Spring Boot), it can be used.
+The `DozerBeanMapperFactoryBean` will detect automatically it from the Spring DI container as global customizers.
+Also, you can specify it to an any `DozerBeanMapperFactoryBean` using `builderCustomizers` property as individual customizers.
+
+In this section, we explain only how to use on Java based configuration.
+If you are using XML based configuration, please replace it with XML code by referring to the other explanations.
+
+.How to implements the DozerBeanMapperBuilderCustomizer
+[source,java,prettyprint]
+----
+import com.github.dozermapper.core.DozerBeanMapperBuilder;
+import com.github.dozermapper.spring.DozerBeanMapperBuilderCustomizer;
+
+public class GlobalBeanMapperBuilderCustomizer
+                implements DozerBeanMapperBuilderCustomizer {
+    @Override
+    public void customize(DozerBeanMapperBuilder builder) {
+        // customize a builder instance ...
+    }
+}
+----
+
+.How to register glbal customizers
+[source,java,prettyprint]
+----
+@Configuration
+public class DozerConfig {
+    @Bean
+    public DozerBeanMapperBuilderCustomizer globalBeanMapperBuilderCustomizer()
+        return new GlobalBeanMapperBuilderCustomizer();
+    }
+}
+----
+
+.How to set individual customizers
+[source,java,prettyprint]
+----
+@Configuration
+public class DozerConfig {
+    @Bean
+    public DozerBeanMapperFactoryBean dozerMapper() {
+        DozerBeanMapperFactoryBean factoryBean = new DozerBeanMapperFactoryBean();
+        factoryBean.setBuilderCustomizers(
+            Collections.singletonList(new IndividualBeanMapperBuilderCustomizer()));
+        // ...
+        return factoryBean;
+    }
+}
+----
+
+[TIP]
+====
+You can create and register a customizer using lambda expression supported by Java 8 without implementation class as follow:
+
+.How to create and register a customizer using lambda expression
+[source,java,prettyprint]
+----
+@Configuration
+public class DozerConfig {
+    @Bean
+    public DozerBeanMapperBuilderCustomizer globalBeanMapperBuilderCustomizer()
+        return builder -> {
+            // customize a builder instance ...
+        };
+    }
+}
+----
+====
+
 === How to use in your application
 
 Using Spring to retrieve the Dozer Mapper......

--- a/dozer-integrations/dozer-spring-support/dozer-spring4/src/main/java/com/github/dozermapper/spring/DozerBeanMapperBuilderCustomizer.java
+++ b/dozer-integrations/dozer-spring-support/dozer-spring4/src/main/java/com/github/dozermapper/spring/DozerBeanMapperBuilderCustomizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2018 Dozer Project
+ * Copyright 2005-2019 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dozer-integrations/dozer-spring-support/dozer-spring4/src/main/java/com/github/dozermapper/spring/DozerBeanMapperBuilderCustomizer.java
+++ b/dozer-integrations/dozer-spring-support/dozer-spring4/src/main/java/com/github/dozermapper/spring/DozerBeanMapperBuilderCustomizer.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2005-2018 Dozer Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.dozermapper.spring;
+
+import com.github.dozermapper.core.DozerBeanMapperBuilder;
+
+/**
+ * The customizer interface for the {@link DozerBeanMapperBuilder}.
+ *
+ * @since 6.5.0
+ */
+public interface DozerBeanMapperBuilderCustomizer {
+
+    /**
+     * Customize a builder.
+     *
+     * @param builder a builder that created by {@link DozerBeanMapperFactoryBean}.
+     */
+    void customize(DozerBeanMapperBuilder builder);
+
+}

--- a/dozer-integrations/dozer-spring-support/dozer-spring4/src/main/java/com/github/dozermapper/spring/DozerBeanMapperFactoryBean.java
+++ b/dozer-integrations/dozer-spring-support/dozer-spring4/src/main/java/com/github/dozermapper/spring/DozerBeanMapperFactoryBean.java
@@ -47,6 +47,7 @@ public class DozerBeanMapperFactoryBean extends ApplicationObjectSupport impleme
     private final List<EventListener> eventListeners = new ArrayList<>(0);
     private final Map<String, BeanFactory> beanFactories = new HashMap<>(0);
     private final Map<String, CustomConverter> customConvertersWithId = new HashMap<>(0);
+    private final List<DozerBeanMapperBuilderCustomizer> builderCustomizers = new ArrayList<>(0);
 
     private Mapper mapper;
 
@@ -141,6 +142,18 @@ public class DozerBeanMapperFactoryBean extends ApplicationObjectSupport impleme
         this.customConvertersWithId.putAll(customConvertersWithId);
     }
 
+    /**
+     * Registers a {@link DozerBeanMapperBuilderCustomizer} for customizing the {@link DozerBeanMapperBuilder}.
+     * <p>
+     * By default, no builder customizers are registered.
+     *
+     * @param builderCustomizers customizers to be configured for the mapper builder.
+     * @since 6.5.0
+     */
+    public void setBuilderCustomizers(List<DozerBeanMapperBuilderCustomizer> builderCustomizers) {
+        this.builderCustomizers.addAll(builderCustomizers);
+    }
+
     // ===
     // Methods for: InitializingBean
     // ===
@@ -154,12 +167,14 @@ public class DozerBeanMapperFactoryBean extends ApplicationObjectSupport impleme
         Map<String, BeanMappingBuilder> contextBeanMappingBuilders = getApplicationContext().getBeansOfType(BeanMappingBuilder.class);
         Map<String, EventListener> contextEventListeners = getApplicationContext().getBeansOfType(EventListener.class);
         Map<String, BeanFactory> contextBeanFactories = getApplicationContext().getBeansOfType(BeanFactory.class);
+        Map<String, DozerBeanMapperBuilderCustomizer> contextBuilderCustomizers = getApplicationContext().getBeansOfType(DozerBeanMapperBuilderCustomizer.class);
 
         customConverters.addAll(contextCustomConvertersWithId.values());
         mappingBuilders.addAll(contextBeanMappingBuilders.values());
         beanFactories.putAll(contextBeanFactories);
         eventListeners.addAll(contextEventListeners.values());
         customConvertersWithId.putAll(contextCustomConvertersWithId);
+        builderCustomizers.addAll(contextBuilderCustomizers.values());
 
         DozerBeanMapperBuilder builder = DozerBeanMapperBuilder.create()
                 .withMappingFiles(mappingFileUrls)
@@ -170,8 +185,7 @@ public class DozerBeanMapperFactoryBean extends ApplicationObjectSupport impleme
                 .withBeanFactorys(beanFactories)
                 .withCustomConvertersWithIds(customConvertersWithId);
 
-        getApplicationContext().getBeansOfType(DozerBeanMapperBuilderCustomizer.class).values()
-                .forEach(customizer -> customizer.customize(builder));
+        builderCustomizers.forEach(customizer -> customizer.customize(builder));
 
         this.mapper = builder.build();
     }

--- a/dozer-integrations/dozer-spring-support/dozer-spring4/src/main/java/com/github/dozermapper/spring/DozerBeanMapperFactoryBean.java
+++ b/dozer-integrations/dozer-spring-support/dozer-spring4/src/main/java/com/github/dozermapper/spring/DozerBeanMapperFactoryBean.java
@@ -161,15 +161,19 @@ public class DozerBeanMapperFactoryBean extends ApplicationObjectSupport impleme
         eventListeners.addAll(contextEventListeners.values());
         customConvertersWithId.putAll(contextCustomConvertersWithId);
 
-        this.mapper = DozerBeanMapperBuilder.create()
+        DozerBeanMapperBuilder builder = DozerBeanMapperBuilder.create()
                 .withMappingFiles(mappingFileUrls)
                 .withCustomFieldMapper(customFieldMapper)
                 .withCustomConverters(customConverters)
                 .withMappingBuilders(mappingBuilders)
                 .withEventListeners(eventListeners)
                 .withBeanFactorys(beanFactories)
-                .withCustomConvertersWithIds(customConvertersWithId)
-                .build();
+                .withCustomConvertersWithIds(customConvertersWithId);
+
+        getApplicationContext().getBeansOfType(DozerBeanMapperBuilderCustomizer.class).values()
+                .forEach(customizer -> customizer.customize(builder));
+
+        this.mapper = builder.build();
     }
 
     // ===

--- a/dozer-integrations/dozer-spring-support/dozer-spring4/src/test/java/com/github/dozermapper/spring/DozerBeanMapperFactoryBeanTest.java
+++ b/dozer-integrations/dozer-spring-support/dozer-spring4/src/test/java/com/github/dozermapper/spring/DozerBeanMapperFactoryBeanTest.java
@@ -22,9 +22,9 @@ import java.util.List;
 
 import com.github.dozermapper.core.BeanFactory;
 import com.github.dozermapper.core.CustomConverter;
-import com.github.dozermapper.core.events.EventListener;
 import com.github.dozermapper.core.Mapper;
 import com.github.dozermapper.core.MapperModelContext;
+import com.github.dozermapper.core.events.EventListener;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -34,7 +34,10 @@ import org.springframework.core.io.Resource;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class DozerBeanMapperFactoryBeanTest {
@@ -97,9 +100,15 @@ public class DozerBeanMapperFactoryBeanTest {
         HashMap<String, EventListener> eventListenerMap = new HashMap<>();
         eventListenerMap.put("a", mock(EventListener.class));
 
+        DozerBeanMapperBuilderCustomizer customizer = mock(DozerBeanMapperBuilderCustomizer.class);
+        HashMap<String, DozerBeanMapperBuilderCustomizer> customizerMap = new HashMap<>();
+        customizerMap.put("a", customizer);
+        customizerMap.put("b", customizer);
+
         when(mockContext.getBeansOfType(CustomConverter.class)).thenReturn(converterHashMap);
         when(mockContext.getBeansOfType(BeanFactory.class)).thenReturn(beanFactoryMap);
         when(mockContext.getBeansOfType(EventListener.class)).thenReturn(eventListenerMap);
+        when(mockContext.getBeansOfType(DozerBeanMapperBuilderCustomizer.class)).thenReturn(customizerMap);
 
         factory.afterPropertiesSet();
 
@@ -113,5 +122,7 @@ public class DozerBeanMapperFactoryBeanTest {
         assertEquals(1, mapperModelContext.getCustomConverters().size());
         assertEquals(1, mapperModelContext.getCustomConvertersWithId().size());
         assertEquals(1, mapperModelContext.getEventListeners().size());
+
+        verify(customizer, times(2)).customize(any());
     }
 }

--- a/dozer-integrations/dozer-spring-support/dozer-spring4/src/test/java/com/github/dozermapper/spring/DozerBeanMapperFactoryBeanTest.java
+++ b/dozer-integrations/dozer-spring-support/dozer-spring4/src/test/java/com/github/dozermapper/spring/DozerBeanMapperFactoryBeanTest.java
@@ -16,6 +16,7 @@
 package com.github.dozermapper.spring;
 
 import java.net.URL;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -66,6 +67,7 @@ public class DozerBeanMapperFactoryBeanTest {
         factory.setMappingFiles(new Resource[] {mockResource});
         factory.setMappingBuilders(Collections.emptyList());
         factory.setCustomFieldMapper(null);
+        factory.setBuilderCustomizers(Collections.emptyList());
 
         factory.afterPropertiesSet();
 
@@ -110,6 +112,8 @@ public class DozerBeanMapperFactoryBeanTest {
         when(mockContext.getBeansOfType(EventListener.class)).thenReturn(eventListenerMap);
         when(mockContext.getBeansOfType(DozerBeanMapperBuilderCustomizer.class)).thenReturn(customizerMap);
 
+        factory.setBuilderCustomizers(Arrays.asList(customizer, customizer));
+
         factory.afterPropertiesSet();
 
         Mapper mapper = factory.getObject();
@@ -123,6 +127,6 @@ public class DozerBeanMapperFactoryBeanTest {
         assertEquals(1, mapperModelContext.getCustomConvertersWithId().size());
         assertEquals(1, mapperModelContext.getEventListeners().size());
 
-        verify(customizer, times(2)).customize(any());
+        verify(customizer, times(4)).customize(any());
     }
 }

--- a/dozer-integrations/dozer-spring-support/dozer-spring4/src/test/java/com/github/dozermapper/spring/functional_tests/SpringIntegrationTest.java
+++ b/dozer-integrations/dozer-spring-support/dozer-spring4/src/test/java/com/github/dozermapper/spring/functional_tests/SpringIntegrationTest.java
@@ -15,6 +15,7 @@
  */
 package com.github.dozermapper.spring.functional_tests;
 
+import java.util.Arrays;
 import java.util.List;
 
 import com.github.dozermapper.core.CustomConverter;
@@ -23,6 +24,7 @@ import com.github.dozermapper.core.Mapper;
 import com.github.dozermapper.core.MapperModelContext;
 import com.github.dozermapper.spring.functional_tests.support.EventTestListener;
 import com.github.dozermapper.spring.functional_tests.support.InjectedCustomConverter;
+import com.github.dozermapper.spring.functional_tests.support.MyBeanMapperBuilderCustomizer;
 import com.github.dozermapper.spring.vo.Destination;
 import com.github.dozermapper.spring.vo.Source;
 
@@ -31,6 +33,7 @@ import org.junit.Test;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -116,6 +119,29 @@ public class SpringIntegrationTest {
 
         assertEquals("John", destination.getValue());
         assertEquals(2L, destination.getId());
+    }
+
+    @Test
+    public void testBuilderCustomizer() {
+        MyBeanMapperBuilderCustomizer.clear();
+        try (ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext("builder-customizer.xml")) {
+            Mapper mapper = context.getBean("beanMapper", Mapper.class);
+            assertNotNull(mapper);
+            assertFalse(context.containsBean("beanMapperWithBuilderCustomizer"));
+            assertEquals(Arrays.asList("globalBuilderCustomizer1", "globalBuilderCustomizer2"),
+                    MyBeanMapperBuilderCustomizer.getHistories());
+        }
+        MyBeanMapperBuilderCustomizer.clear();
+        try (ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext()) {
+            context.getEnvironment().setActiveProfiles("withBuilderCustomizer");
+            context.setConfigLocation("builder-customizer.xml");
+            context.refresh();
+            Mapper mapper = context.getBean("beanMapperWithBuilderCustomizer", Mapper.class);
+            assertNotNull(mapper);
+            assertFalse(context.containsBean("beanMapper"));
+            assertEquals(Arrays.asList("builderCustomizer1", "builderCustomizer2", "globalBuilderCustomizer1", "globalBuilderCustomizer2"),
+                    MyBeanMapperBuilderCustomizer.getHistories());
+        }
     }
 
     private void assertBasicMapping(Mapper mapper) {

--- a/dozer-integrations/dozer-spring-support/dozer-spring4/src/test/java/com/github/dozermapper/spring/functional_tests/support/MyBeanMapperBuilderCustomizer.java
+++ b/dozer-integrations/dozer-spring-support/dozer-spring4/src/test/java/com/github/dozermapper/spring/functional_tests/support/MyBeanMapperBuilderCustomizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2005-2018 Dozer Project
+ * Copyright 2005-2019 Dozer Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/dozer-integrations/dozer-spring-support/dozer-spring4/src/test/java/com/github/dozermapper/spring/functional_tests/support/MyBeanMapperBuilderCustomizer.java
+++ b/dozer-integrations/dozer-spring-support/dozer-spring4/src/test/java/com/github/dozermapper/spring/functional_tests/support/MyBeanMapperBuilderCustomizer.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2005-2018 Dozer Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.dozermapper.spring.functional_tests.support;
+
+import com.github.dozermapper.core.DozerBeanMapperBuilder;
+import com.github.dozermapper.spring.DozerBeanMapperBuilderCustomizer;
+import org.springframework.beans.factory.BeanNameAware;
+import org.springframework.core.Ordered;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class MyBeanMapperBuilderCustomizer implements DozerBeanMapperBuilderCustomizer, BeanNameAware, Ordered {
+
+    private static List<String> histories = new ArrayList<>();
+
+    private final int order;
+    private String beanName;
+
+    public MyBeanMapperBuilderCustomizer() {
+        this.order = 0;
+    }
+
+    public MyBeanMapperBuilderCustomizer(int order) {
+        this.order = order;
+    }
+
+    @Override
+    public void customize(DozerBeanMapperBuilder builder) {
+        histories.add(beanName);
+    }
+
+    @Override
+    public void setBeanName(String name) {
+        this.beanName = name;
+    }
+
+    @Override
+    public int getOrder() {
+        return order;
+    }
+
+    public static List<String> getHistories() {
+        return histories;
+    }
+
+    public static void clear() {
+        histories.clear();
+    }
+
+}

--- a/dozer-integrations/dozer-spring-support/dozer-spring4/src/test/resources/builder-customizer.xml
+++ b/dozer-integrations/dozer-spring-support/dozer-spring4/src/test/resources/builder-customizer.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2005-2018 Dozer Project
+    Copyright 2005-2019 Dozer Project
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/dozer-integrations/dozer-spring-support/dozer-spring4/src/test/resources/builder-customizer.xml
+++ b/dozer-integrations/dozer-spring-support/dozer-spring4/src/test/resources/builder-customizer.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2005-2018 Dozer Project
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:dozer="http://dozermapper.github.io/schema/dozer-spring"
+       xsi:schemaLocation="
+          http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+          http://dozermapper.github.io/schema/dozer-spring https://dozermapper.github.io/schema/dozer-spring.xsd">
+
+    <bean id="globalBuilderCustomizer1" class="com.github.dozermapper.spring.functional_tests.support.MyBeanMapperBuilderCustomizer">
+        <constructor-arg value="1"/>
+    </bean>
+
+    <bean id="globalBuilderCustomizer2" class="com.github.dozermapper.spring.functional_tests.support.MyBeanMapperBuilderCustomizer">
+        <constructor-arg value="1"/>
+    </bean>
+
+    <beans profile="default">
+        <dozer:mapper id="beanMapper"/>
+    </beans>
+
+    <beans profile="withBuilderCustomizer">
+        <bean id="beanMapperWithBuilderCustomizer" class="com.github.dozermapper.spring.DozerBeanMapperFactoryBean">
+            <property name="builderCustomizers">
+                <list>
+                    <bean id="builderCustomizer1" class="com.github.dozermapper.spring.functional_tests.support.MyBeanMapperBuilderCustomizer" />
+                    <bean id="builderCustomizer2" class="com.github.dozermapper.spring.functional_tests.support.MyBeanMapperBuilderCustomizer" />
+                </list>
+            </property>
+        </bean>
+    </beans>
+
+</beans>
+


### PR DESCRIPTION
I propose to support the the customizer interface of `DozerBeanMapperBuilder`.
By this changes, Spring(Spring Boot) user's can will be customize easily and fully a builder instance created by `DozerBeanMapperFactoryBean`.

## Open Questions and Pre-Merge TODOs
- [ ] Issue created
- [x] Unit tests pass
- [x] Documentation updated
- [x] Travis build passed
