### PR TITLE
 Add converter for java.time.Instant (#731)

### DIFF
--- a/core/src/main/java/com/github/dozermapper/core/converters/InstantConverter.java
+++ b/core/src/main/java/com/github/dozermapper/core/converters/InstantConverter.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2005-2018 Dozer Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.dozermapper.core.converters;
+
+import java.time.Instant;
+import java.time.temporal.TemporalAccessor;
+import java.util.Date;
+
+import org.apache.commons.beanutils.Converter;
+
+/**
+ * Internal converter to {@link Instant} type. Only intended for internal use.
+ */
+public final class InstantConverter implements Converter {
+
+    @Override
+    public Object convert(Class destClass, Object srcObject) {
+        Class<?> srcObjectClass = srcObject.getClass();
+
+        if (Date.class.isAssignableFrom(srcObjectClass)) {
+            Instant instant = ((Date) srcObject).toInstant();
+            return instant;
+        } else if (Instant.class.isAssignableFrom(srcObjectClass)) {
+            return Instant.from((Instant) srcObject);
+        } else if (TemporalAccessor.class.isAssignableFrom(srcObjectClass)) {
+            return Instant.from((TemporalAccessor) srcObject);
+        } else if (String.class.isAssignableFrom(srcObjectClass)) {
+            return Instant.parse((String) srcObject);
+        } else {
+            throw new ConversionException(String.format("Unsupported source object type: %s", srcObjectClass), null);
+        }
+    }
+}

--- a/core/src/main/java/com/github/dozermapper/core/converters/PrimitiveOrWrapperConverter.java
+++ b/core/src/main/java/com/github/dozermapper/core/converters/PrimitiveOrWrapperConverter.java
@@ -17,6 +17,7 @@ package com.github.dozermapper.core.converters;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -117,6 +118,8 @@ public class PrimitiveOrWrapperConverter {
                 result = new OffsetDateTimeConverter(dateFormatContainer.getDateTimeFormatter());
             } else if (ZonedDateTime.class.isAssignableFrom(destClass)) {
                 result = new ZonedDateTimeConverter(dateFormatContainer.getDateTimeFormatter());
+            } else if (Instant.class.isAssignableFrom(destClass)) {
+                result = new InstantConverter();
             }
         }
         return result == null ? new StringConstructorConverter(dateFormatContainer) : result;
@@ -136,7 +139,8 @@ public class PrimitiveOrWrapperConverter {
                || LocalTime.class.isAssignableFrom(aClass)
                || OffsetDateTime.class.isAssignableFrom(aClass)
                || OffsetTime.class.isAssignableFrom(aClass)
-               || ZonedDateTime.class.isAssignableFrom(aClass);
+               || ZonedDateTime.class.isAssignableFrom(aClass)
+               || Instant.class.isAssignableFrom(aClass);
     }
 
     private static boolean isLocalTime(Class clazz) {

--- a/core/src/test/java/com/github/dozermapper/core/converters/InstantConverterTest.java
+++ b/core/src/test/java/com/github/dozermapper/core/converters/InstantConverterTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2005-2018 Dozer Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.dozermapper.core.converters;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.Date;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class InstantConverterTest {
+
+    private final InstantConverter converter = new InstantConverter();
+
+    @Test
+    public void canConvertFromInstantToInstant() {
+        Instant sourceObject = ZonedDateTime.of(LocalDateTime.of(2017, 11, 2, 10, 0), ZoneOffset.UTC).toInstant();
+        Instant expected = ZonedDateTime.of(LocalDateTime.of(2017, 11, 2, 10, 0), ZoneOffset.UTC).toInstant();
+
+        Object result = converter.convert(Instant.class, sourceObject);
+
+        assertTrue(result instanceof Instant);
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void canConvertFromStringToInstant() {
+        String sourceObject = "2017-11-02T10:20:30.00Z";
+        Instant expected = ZonedDateTime.of(LocalDateTime.of(2017, 11, 2, 10, 20, 30), ZoneOffset.UTC).toInstant();
+
+        Object result = converter.convert(Instant.class, sourceObject);
+
+        assertTrue(result instanceof Instant);
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void canConvertFromZonedDateTimeToInstant() {
+        ZonedDateTime sourceObject = ZonedDateTime.of(LocalDateTime.of(2017, 11, 2, 10, 20, 30), ZoneOffset.UTC);
+        Instant expected = ZonedDateTime.of(LocalDateTime.of(2017, 11, 2, 10, 20, 30), ZoneOffset.UTC).toInstant();
+
+        Object result = converter.convert(Instant.class, sourceObject);
+
+        assertTrue(result instanceof Instant);
+        assertEquals(expected, result);
+    }
+
+    @Test
+    public void canConvertFromDateToInstant() {
+        Date sourceObject = new Date(Instant.parse("2017-11-02T10:20:30.00Z").toEpochMilli());
+        Instant expected = ZonedDateTime.of(LocalDateTime.of(2017, 11, 2, 10, 20, 30), ZoneOffset.UTC).toInstant();
+
+        Object result = converter.convert(Instant.class, sourceObject);
+
+        assertTrue(result instanceof Instant);
+        assertEquals(expected, result);
+    }
+}


### PR DESCRIPTION
## Issue link

#731  java.time.Instant Not Supported

## Purpose

Add a converter for java.time.Instant.

## Approach

The added converter can convert : 
* Date to Instant
* Instant to Instant
* Temporal to Instant
* String to Instant

## Open Questions and Pre-Merge TODOs
- [x] Issue created
- [x] Unit tests pass
- [ ] Documentation updated
- [x] Travis build passed
