### PR TITLE
Add missing skipConstructor method to API (#218)

### DIFF
--- a/core/src/main/java/com/github/dozermapper/core/loader/api/TypeDefinition.java
+++ b/core/src/main/java/com/github/dozermapper/core/loader/api/TypeDefinition.java
@@ -29,6 +29,7 @@ public class TypeDefinition {
     private String mapSetMethod;
     private Boolean mapNull;
     private Boolean isAccessible;
+    private Boolean skipConstructor;
 
     public TypeDefinition(Class<?> type) {
         this.name = type.getName();
@@ -50,6 +51,7 @@ public class TypeDefinition {
         typeBuilder.mapSetMethod(this.mapSetMethod);
 
         typeBuilder.isAccessible(this.isAccessible);
+        typeBuilder.skipConstructor(this.skipConstructor);
     }
 
     public TypeDefinition mapMethods(String getMethod, String setMethod) {
@@ -103,6 +105,11 @@ public class TypeDefinition {
     public TypeDefinition accessible(boolean value) {
         this.isAccessible = value;
         return this;
+    }
+    
+    public TypeDefinition skipConstructor(boolean value) {
+    	this.skipConstructor = value;
+    	return this;
     }
 
     public String getName() {

--- a/core/src/main/java/com/github/dozermapper/core/loader/api/TypeDefinition.java
+++ b/core/src/main/java/com/github/dozermapper/core/loader/api/TypeDefinition.java
@@ -106,10 +106,10 @@ public class TypeDefinition {
         this.isAccessible = value;
         return this;
     }
-    
+
     public TypeDefinition skipConstructor(boolean value) {
-    	this.skipConstructor = value;
-    	return this;
+        this.skipConstructor = value;
+        return this;
     }
 
     public String getName() {

--- a/docs/asciidoc/documentation/apiConfiguration.adoc
+++ b/docs/asciidoc/documentation/apiConfiguration.adoc
@@ -10,7 +10,7 @@ Mapper mapper = DozerBeanMapperBuilder.create()
                     @Override
                     protected void configure() {
                         mapping(type(A.class).mapEmptyString(true),
-                                type(B.class),
+                                type(B.class).skipConstructor(true),
                                 TypeMappingOptions.wildcardCaseInsensitive(true)
                         ).fields(
                                 field("fieldOfA").getMethod("getTheField"),


### PR DESCRIPTION
It is possible configure skip-constructor by XML but not in the API. The method "skipConstructor" is now added in TypeDefinition.java.