### PR TITLE
Upgrade to beanutils-1.9.4

### DIFF
--- a/bom-dependencies/pom.xml
+++ b/bom-dependencies/pom.xml
@@ -35,7 +35,7 @@
     <properties>
         <!-- Dependency versions; alphabetical order -->
         <cglib-nodep.version>3.2.9</cglib-nodep.version>
-        <commons-beanutils.version>1.9.3</commons-beanutils.version>
+        <commons-beanutils.version>1.9.4</commons-beanutils.version>
         <commons-lang3.version>3.7</commons-lang3.version>
         <commons-io.version>2.5</commons-io.version>
         <javax.el.version>3.0.0</javax.el.version>

--- a/core/src/test/java/com/github/dozermapper/core/util/ReflectionUtilsTest.java
+++ b/core/src/test/java/com/github/dozermapper/core/util/ReflectionUtilsTest.java
@@ -101,7 +101,7 @@ public class ReflectionUtilsTest extends AbstractDozerTest {
         assertEquals(1, descriptors.length);
 
         descriptors = ReflectionUtils.getInterfacePropertyDescriptors(TestClass.class);
-        assertEquals(4, descriptors.length);
+        assertEquals(3, descriptors.length);
     }
 
     @Test

--- a/tests/dozer-osgi-tests/src/test/java/com/github/dozermapper/osgitests/support/BundleOptions.java
+++ b/tests/dozer-osgi-tests/src/test/java/com/github/dozermapper/osgitests/support/BundleOptions.java
@@ -38,7 +38,7 @@ public final class BundleOptions {
     public static Option coreBundles() {
         return composite(
                 // Commons
-                localBundle("org.apache.commons.beanutils.link"),
+                localBundle("org.apache.commons.commons-beanutils.link"),
                 localBundle("org.apache.commons.collections.link"),
                 localBundle("org.apache.commons.lang3.link"),
                 localBundle("org.apache.commons.io.link"),


### PR DESCRIPTION
## Issue link
[ISSUE:767](https://github.com/DozerMapper/dozer/issues/767) Upgrade beanutils to 1.9.4

## Purpose
To address a security vulnerability reported in [CVE-2019-10086](https://www.cvedetails.com/cve/CVE-2019-10086/)

## Approach
Upgrade pom.xml to version 1.9.4       

## Open Questions and Pre-Merge TODOs
- [x] Issue created
- [x] Unit tests pass
- [x] Travis build passed
