### PR TITLE
Typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ SourceClassName sourceObject = new SourceClassName();
 sourceObject.setYourSourceFieldName("Dozer");
 
 Mapper mapper = DozerBeanMapperBuilder.buildDefault();
-DestinationObject destObject = mapper.map(sourceObject, DestinationClassName.class);
+DestinationClassName destObject = mapper.map(sourceObject, DestinationClassName.class);
 
 assertTrue(destObject.getYourDestinationFieldName().equals(sourceObject.getYourSourceFieldName()));
 ```


### PR DESCRIPTION
## Purpose
_Minor typo fixed in the README_

## Approach

It seems that the object type of destination object should be `DestinationClassName`

## Open Questions and Pre-Merge TODOs
- [ ] Issue created
- [ ] Unit tests pass
- [X] Documentation updated
- [ ] Travis build passed
