### PR TITLE
[ISSUE: 739] Added transaction support to MappedFieldsTracker

### DIFF
--- a/core/src/main/java/com/github/dozermapper/core/MapIdField.java
+++ b/core/src/main/java/com/github/dozermapper/core/MapIdField.java
@@ -35,6 +35,10 @@ public class MapIdField {
         mappedObjects.put(mapId, value);
     }
 
+    public void remove(String mapId) {
+        mappedObjects.remove(mapId);
+    }
+
     public Object get(String mapId) {
         return mappedObjects.get(mapId);
     }

--- a/core/src/main/java/com/github/dozermapper/core/MappedFieldsTracker.java
+++ b/core/src/main/java/com/github/dozermapper/core/MappedFieldsTracker.java
@@ -15,9 +15,15 @@
  */
 package com.github.dozermapper.core;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.IdentityHashMap;
+import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Keeps track of mapped object during this mapping process execution.
@@ -26,9 +32,106 @@ import java.util.Map;
  */
 public class MappedFieldsTracker {
 
+    private static class UndoLogEntry {
+
+        private final MapIdField destMapIdField;
+        private final String mapId;
+
+        UndoLogEntry(MapIdField destMapIdField, String mapId) {
+            this.destMapIdField = destMapIdField;
+            this.mapId = mapId;
+        }
+
+        void revert() {
+            destMapIdField.remove(mapId);
+        }
+    }
+
+    private static class UndoLog {
+
+        private List<UndoLogEntry> ops = new ArrayList<>();
+
+        void track(MapIdField destMapIdField, String mapId) {
+            this.ops.add(new UndoLogEntry(destMapIdField, mapId));
+        }
+
+        void revert() {
+            for (UndoLogEntry op : this.ops) {
+                op.revert();
+            }
+        }
+    }
+
+    private static final int NO_TX_ID = -1;
+
+    // Counter used for generation of transaction IDs.
+    private final AtomicInteger txId = new AtomicInteger(NO_TX_ID);
+
     // Hash Code is ignored as it can serve application specific needs
     // <srcObject, <hashCodeOfDestination, mappedDestinationMapIdField>>
     private final Map<Object, Map<Integer, MapIdField>> mappedFields = new IdentityHashMap<>();
+
+    // Map with the Undo-Logs of pending transactions indexed and sorted by transaction IDs.
+    private SortedMap<Integer, UndoLog> pendingTransactions = new TreeMap<>();
+
+    /**
+     * Start a new transaction which supports commit or rollback. Nested transaction are also supported and may be
+     * individually rollbacked. Even if nested transactions are commited they may still be rollbacked by the rollback
+     * of an outer transaction until the root transaction is committed as well.
+     * @return transaction ID that can be used for commit or rollback of the transaction
+     * @see #commitTransaction(Integer)
+     * @see #rollbackTransaction(Integer)
+     */
+    public Integer startTransaction() {
+        int curTxId = this.txId.incrementAndGet();
+        this.pendingTransactions.put(curTxId, new UndoLog());
+        return curTxId;
+    }
+
+    /**
+     * Commit transaction with the given ID. The operations executed under this transaction my still be reverted by the
+     * rollback of a parent transaction (if any).
+     * @param txId - transaction ID as returned by {@link #startTransaction()}
+     */
+    public void commitTransaction(Integer txId) {
+        final UndoLog undoLog = pendingTransactions.get(txId);
+        if (undoLog == null) {
+            throw new IllegalStateException("No transaction with ID " + txId);
+        }
+        if (pendingTransactions.firstKey().equals(txId)) {
+            // commit of root transaction
+            pendingTransactions.clear();
+        }
+    }
+
+    /**
+     * Rollback transaction with the given ID. The operations of this transactions as well as those of nested
+     * transactions are reverted.
+     * @param txId - transaction ID as returned by {@link #startTransaction()}
+     */
+    public void rollbackTransaction(Integer txId) {
+        final UndoLog undoLog = pendingTransactions.get(txId);
+        if (undoLog == null) {
+            throw new IllegalStateException("No transaction with ID " + txId);
+        }
+
+        // rollback nested transactions
+        SortedMap<Integer, UndoLog> undoLogs = pendingTransactions.tailMap(txId);
+        Iterator<UndoLog> undoLogIterator = undoLogs.values().iterator();
+        while (undoLogIterator.hasNext()) {
+            UndoLog curUndoLog = undoLogIterator.next();
+            curUndoLog.revert();
+            undoLogIterator.remove();
+        }
+    }
+
+    /**
+     * Checks if there is a transaction active.
+     * @return <code>true</code> if a transaction is active, <code>false</code> otherwise
+     */
+    public boolean hasTransaction() {
+        return pendingTransactions.size() > 0;
+    }
 
     public void put(Object src, Object dest, String mapId) {
         int destId = System.identityHashCode(dest);
@@ -47,6 +150,10 @@ public class MappedFieldsTracker {
 
         if (!destMapIdField.containsMapId(mapId)) {
             destMapIdField.put(mapId, dest);
+            if (hasTransaction()) {
+                UndoLog undoLog = this.pendingTransactions.get(txId.get());
+                undoLog.track(destMapIdField, mapId);
+            }
         }
     }
 

--- a/core/src/main/java/com/github/dozermapper/core/MappingProcessor.java
+++ b/core/src/main/java/com/github/dozermapper/core/MappingProcessor.java
@@ -811,6 +811,7 @@ public class MappingProcessor implements Mapper {
                 destEntryType = determineCollectionItemType(fieldMap, destObj, srcValue, prevDestEntryType);
             }
 
+            Integer tx = mappedFields.startTransaction();
             CopyByReferenceContainer copyByReferences = globalConfiguration.getCopyByReferences();
             if (srcValue != null && copyByReferences.contains(srcValue.getClass())) {
                 destValue = srcValue;
@@ -821,6 +822,7 @@ public class MappingProcessor implements Mapper {
 
             if (RelationshipType.NON_CUMULATIVE.equals(fieldMap.getRelationshipType())
                 && result.contains(destValue)) {
+                mappedFields.rollbackTransaction(tx); // rollback side effects of dry-run
                 List<Object> resultAsList = new ArrayList<>(result);
                 int index = resultAsList.indexOf(destValue);
                 // perform an update if complex type - can't map strings
@@ -831,6 +833,7 @@ public class MappingProcessor implements Mapper {
                     mappedElements.add(obj);
                 }
             } else {
+                mappedFields.commitTransaction(tx);
                 if (destValue != null || fieldMap.isDestMapNull()) {
                     result.add(destValue);
                 }
@@ -874,6 +877,7 @@ public class MappingProcessor implements Mapper {
                 destEntryType = determineCollectionItemType(fieldMap, destObj, srcValue, prevDestEntryType);
             }
 
+            Integer tx = mappedFields.startTransaction();
             CopyByReferenceContainer copyByReferences = globalConfiguration.getCopyByReferences();
             if (srcValue != null && copyByReferences.contains(srcValue.getClass())) {
                 destValue = srcValue;
@@ -884,6 +888,7 @@ public class MappingProcessor implements Mapper {
 
             if (RelationshipType.NON_CUMULATIVE.equals(fieldMap.getRelationshipType())
                 && result.contains(destValue)) {
+                mappedFields.rollbackTransaction(tx); // rollback side effects of dry-run
                 int index = result.indexOf(destValue);
                 // perform an update if complex type - can't map strings
                 Object obj = result.get(index);
@@ -893,6 +898,7 @@ public class MappingProcessor implements Mapper {
                     mappedElements.add(obj);
                 }
             } else {
+                mappedFields.commitTransaction(tx);
                 // respect null mappings
                 if (destValue != null || fieldMap.isDestMapNull()) {
                     result.add(destValue);

--- a/core/src/test/java/com/github/dozermapper/core/MapIdFieldTest.java
+++ b/core/src/test/java/com/github/dozermapper/core/MapIdFieldTest.java
@@ -52,4 +52,11 @@ public class MapIdFieldTest {
         assertFalse(mapIdField.containsMapId(null));
     }
 
+    @Test
+    public void testRemove() {
+        mapIdField.put("aMapId", "aMapIdValue");
+        mapIdField.remove("aMapId");
+        assertFalse(mapIdField.containsMapId("aMapId"));
+    }
+
 }

--- a/core/src/test/java/com/github/dozermapper/core/MappedFieldsTrackerTest.java
+++ b/core/src/test/java/com/github/dozermapper/core/MappedFieldsTrackerTest.java
@@ -19,13 +19,20 @@ import java.util.HashSet;
 import java.util.Set;
 
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 
 public class MappedFieldsTrackerTest extends AbstractDozerTest {
+
+    @Rule
+    public final ExpectedException exception = ExpectedException.none();
 
     private MappedFieldsTracker tracker;
 
@@ -87,6 +94,144 @@ public class MappedFieldsTrackerTest extends AbstractDozerTest {
         public boolean equals(Object obj) {
             throw new RuntimeException();
         }
+    }
+
+    @Test
+    public void testTransaction_commit() {
+        tracker.put("1", "1");
+
+        assertFalse(tracker.hasTransaction());
+        Integer txId = tracker.startTransaction();
+        assertTrue(tracker.hasTransaction());
+        assertEquals(Integer.valueOf(0), txId);
+
+        tracker.put("2", "2");
+        assertEquals("1", tracker.getMappedValue("1", String.class));
+        assertEquals("2", tracker.getMappedValue("2", String.class));
+
+        tracker.commitTransaction(txId);
+        assertFalse(tracker.hasTransaction());
+        assertEquals("1", tracker.getMappedValue("1", String.class));
+        assertEquals("2", tracker.getMappedValue("2", String.class));
+    }
+
+    @Test
+    public void testTransaction_rollback() {
+        tracker.put("1", "1");
+
+        assertFalse(tracker.hasTransaction());
+        Integer txId = tracker.startTransaction();
+        assertTrue(tracker.hasTransaction());
+        assertEquals(Integer.valueOf(0), txId);
+
+        tracker.put("2", "2");
+        assertEquals("1", tracker.getMappedValue("1", String.class));
+        assertEquals("2", tracker.getMappedValue("2", String.class));
+
+        tracker.rollbackTransaction(txId);
+        assertFalse(tracker.hasTransaction());
+        assertEquals("1", tracker.getMappedValue("1", String.class));
+        assertNull(tracker.getMappedValue("2", String.class));
+    }
+
+    @Test
+    public void testTransaction_nestedRollback() {
+        tracker.put("1", "1");
+
+        // start root transaction
+        Integer txIdRoot = tracker.startTransaction();
+        assertTrue(tracker.hasTransaction());
+        tracker.put("2", "2");
+
+        // start nested transaction
+        Integer txIdNested = tracker.startTransaction();
+        assertTrue(tracker.hasTransaction());
+        tracker.put("3", "3");
+
+        // rollback nested transaction
+        tracker.rollbackTransaction(txIdNested);
+        assertTrue(tracker.hasTransaction());
+        assertNull(tracker.getMappedValue("3", String.class));
+        assertEquals("2", tracker.getMappedValue("2", String.class));
+        assertEquals("1", tracker.getMappedValue("1", String.class));
+
+        // commit root transaction
+        tracker.commitTransaction(txIdRoot);
+        assertFalse(tracker.hasTransaction());
+        assertEquals("2", tracker.getMappedValue("2", String.class));
+        assertEquals("1", tracker.getMappedValue("1", String.class));
+    }
+
+    @Test
+    public void testTransaction_nestedCommit() {
+        tracker.put("1", "1");
+
+        // start root transaction
+        Integer txIdRoot = tracker.startTransaction();
+        assertTrue(tracker.hasTransaction());
+        tracker.put("2", "2");
+
+        // start nested transaction
+        Integer txIdNested = tracker.startTransaction();
+        assertTrue(tracker.hasTransaction());
+        tracker.put("3", "3");
+
+        // rollback nested transaction
+        tracker.commitTransaction(txIdNested);
+        assertTrue(tracker.hasTransaction());
+        assertEquals("3", tracker.getMappedValue("3", String.class));
+        assertEquals("2", tracker.getMappedValue("2", String.class));
+        assertEquals("1", tracker.getMappedValue("1", String.class));
+
+        // commit root transaction
+        tracker.commitTransaction(txIdRoot);
+        assertFalse(tracker.hasTransaction());
+        assertEquals("3", tracker.getMappedValue("3", String.class));
+        assertEquals("2", tracker.getMappedValue("2", String.class));
+        assertEquals("1", tracker.getMappedValue("1", String.class));
+    }
+
+    @Test
+    public void testTransaction_nestedOuterRollback() {
+        tracker.put("1", "1");
+
+        // start root transaction
+        Integer txIdRoot = tracker.startTransaction();
+        assertTrue(tracker.hasTransaction());
+        tracker.put("2", "2");
+
+        // start nested transaction
+        Integer txIdNested = tracker.startTransaction();
+        assertTrue(tracker.hasTransaction());
+        tracker.put("3", "3");
+
+        // rollback nested transaction
+        tracker.commitTransaction(txIdNested);
+        assertTrue(tracker.hasTransaction());
+        assertEquals("3", tracker.getMappedValue("3", String.class));
+        assertEquals("2", tracker.getMappedValue("2", String.class));
+        assertEquals("1", tracker.getMappedValue("1", String.class));
+
+        // commit root transaction
+        tracker.rollbackTransaction(txIdRoot);
+        assertFalse(tracker.hasTransaction());
+        assertNull(tracker.getMappedValue("3", String.class));
+        assertNull(tracker.getMappedValue("2", String.class));
+        assertEquals("1", tracker.getMappedValue("1", String.class));
+    }
+
+    @Test
+    public void testTransaction_unknownCommit() {
+        exception.expect(IllegalStateException.class);
+        exception.expectMessage("No transaction with ID 0");
+        tracker.commitTransaction(0);
+    }
+
+    @Test
+    public void testTransaction_unknownRollback() {
+        exception.expect(IllegalStateException.class);
+        exception.expectMessage("No transaction with ID 0");
+        tracker.rollbackTransaction(0);
     }
 
 }

--- a/core/src/test/java/com/github/dozermapper/core/functional_tests/CumulativeMappingTest.java
+++ b/core/src/test/java/com/github/dozermapper/core/functional_tests/CumulativeMappingTest.java
@@ -46,25 +46,32 @@ public class CumulativeMappingTest extends AbstractFunctionalTest {
     @Test
     public void testMapping() {
         Library libSrc = newInstance(Library.class);
-        Author author = newInstance(Author.class, new Object[] {"The Best One", new Long(505L)});
-        Book book = newInstance(Book.class, new Object[] {new Long(141L), author});
+        Author author = newInstance(Author.class, new Object[] {505L, "The Best One"});
+        Book book = newInstance(Book.class, new Object[] {141L, author});
         libSrc.setBooks(Collections.singletonList(book));
 
         LibraryPrime libDest = newInstance(LibraryPrime.class);
-        AuthorPrime authorPrime = newInstance(AuthorPrime.class, new Object[] {new Long(505L), "The Ultimate One", new Long(5100L)});
-        BookPrime bookDest = newInstance(BookPrime.class, new Object[] {new Long(141L), authorPrime});
+        AuthorPrime authorPrime = newInstance(AuthorPrime.class, new Object[] {505L, "The Ultimate One", 5100L});
+        BookPrime bookDest = newInstance(BookPrime.class, new Object[] {141L, authorPrime});
         List<BookPrime> bookDests = newInstance(ArrayList.class);
         bookDests.add(bookDest);
         libDest.setBooks(bookDests);
 
         mapper.map(libSrc, libDest);
 
+        // verify book collection
+        assertEquals(bookDests, libDest.getBooks()); // reuse existing collection in destination object
         assertEquals(1, libDest.getBooks().size());
-        BookPrime bookPrime = (BookPrime)libDest.getBooks().get(0);
-        assertEquals(new Long(141L), bookPrime.getId());
-        assertEquals("The Best One", bookPrime.getAuthor().getName());
 
-        //    assertEquals(new Long(5100L), book.getAuthor().getSalary()); TODO Enable this for non-cumulative recursion bug
+        // verify book
+        BookPrime bookPrime = libDest.getBooks().get(0);
+        assertEquals(bookDest, bookPrime); // reuse existing item in collection on destination object
+        assertEquals(Long.valueOf(141L), bookPrime.getId());
+
+        // verify author
+        assertEquals(authorPrime, bookPrime.getAuthor());
+        assertEquals("The Best One", bookPrime.getAuthor().getName());
+        assertEquals(Long.valueOf(5100L), bookPrime.getAuthor().getSalary());
     }
 
 }

--- a/core/src/test/java/com/github/dozermapper/core/vo/cumulative/Author.java
+++ b/core/src/test/java/com/github/dozermapper/core/vo/cumulative/Author.java
@@ -23,7 +23,7 @@ public class Author {
     public Author() {
     }
 
-    public Author(String name, Long id) {
+    public Author(Long id, String name) {
         super();
         this.name = name;
         this.id = id;

--- a/core/src/test/java/com/github/dozermapper/core/vo/cumulative/Library.java
+++ b/core/src/test/java/com/github/dozermapper/core/vo/cumulative/Library.java
@@ -19,13 +19,13 @@ import java.util.List;
 
 public class Library {
 
-    List books;
+    private List<Book> books;
 
-    public List getBooks() {
+    public List<Book> getBooks() {
         return books;
     }
 
-    public void setBooks(List books) {
+    public void setBooks(List<Book> books) {
         this.books = books;
     }
 

--- a/core/src/test/java/com/github/dozermapper/core/vo/cumulative/LibraryPrime.java
+++ b/core/src/test/java/com/github/dozermapper/core/vo/cumulative/LibraryPrime.java
@@ -19,16 +19,13 @@ import java.util.List;
 
 public class LibraryPrime {
 
-    List books;
+    private List<BookPrime> books;
 
-    public LibraryPrime() {
-    }
-
-    public List getBooks() {
+    public List<BookPrime> getBooks() {
         return books;
     }
 
-    public void setBooks(List books) {
+    public void setBooks(List<BookPrime> books) {
         this.books = books;
     }
 


### PR DESCRIPTION
This fixes https://github.com/DozerMapper/dozer/issues/739.

## Purpose
With this in place, nested objects on list items are re-used instead and not re-created (see detailed explanation in https://github.com/DozerMapper/dozer/issues/739).
There was already a check in test case `CumulativeMappingTest` which had been commented out with _"TODO Enable this for non-cumulative recursion bug"_. Now this is working as expected.

## Approach
Side-effects in MappedFieldsTracker, that occur when creating a comparison object for list mapping with `relationship-type="non-cumulative"`, can now be isolated in a transaction and individually rollbacked if a matching item is found and should be used instead.

## Open Questions and Pre-Merge TODOs
- [x] Issue created
- [x] Unit tests pass
- [ ] Documentation updated
- [ ] Travis build passed
