### PR TITLE
ProtoUtils getFullyQualifiedClassName

### DIFF
--- a/dozer-integrations/dozer-proto3/src/main/java/com/github/dozermapper/protobuf/util/ProtoUtils.java
+++ b/dozer-integrations/dozer-proto3/src/main/java/com/github/dozermapper/protobuf/util/ProtoUtils.java
@@ -228,8 +228,7 @@ public final class ProtoUtils {
             fqnSegments.push(fileOpts.getJavaPackage());
             return fqnSegments.toArray(new String[] {});
         }
-
-        return new String[] {fileOpts.getJavaPackage(), fileOpts.getJavaOuterClassname(), name};
+        return Stream.of(fileOpts.getJavaPackage(), fileOpts.getJavaOuterClassname(), name).filter(n -> !n.isEmpty()).toArray();
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
getFullyQualifiedClassName ignore empty path

## Issue link
_All PRs **MUST** have a corresponding issue linked and issue number in PR name. i.e.:_
[[ISSUE: 805] ProtoUtils getFullyQualifiedClassName](https://github.com/DozerMapper/dozer/issues/805)
## Purpose
_Describe the problem or feature_
descriptor.getFile().getOptions() may be is empty


## Approach
_How does this change address the problem?_
combine string arrays ignore empty string

## Open Questions and Pre-Merge TODOs
- [x] Issue created
- [ ] Unit tests pass
- [ ] Documentation updated
- [ ] Travis build passed
