### PR TITLE
Ignore synthetic fields on extracting declared fields in ClassLevelFieldMappingGenerator

### DIFF
--- a/core/src/main/java/com/github/dozermapper/core/classmap/generator/ClassLevelFieldMappingGenerator.java
+++ b/core/src/main/java/com/github/dozermapper/core/classmap/generator/ClassLevelFieldMappingGenerator.java
@@ -101,7 +101,9 @@ public class ClassLevelFieldMappingGenerator implements ClassMapBuilder.ClassMap
 
         do {
             for (Field field : srcType.getDeclaredFields()) {
-                declaredFieldNames.add(field.getName());
+                if (!field.isSynthetic()) {
+                    declaredFieldNames.add(field.getName());
+                }
             }
 
             srcType = srcType.getSuperclass();


### PR DESCRIPTION
## Issue link
[ISSUE: #763] ClassLevelFieldMappingGenerator should ignore synthetic fields

## Purpose
Currently ClassLevelFieldMappingGenerator extracts all fields by reflection. This also includes synthetic fields. This causes problems if source code is instrumented e.g. by JaCoCo. For JaCoCo this can lead to out of memory situations.

## Approach
As described here in the [JaCoCo Faq](https://www.eclemma.org/jacoco/trunk/doc/faq.html), the PR ignores synthetic fields in ClassLevelFieldMappingGenerator. 

## Open Questions and Pre-Merge TODOs
- [x] Issue created
- [x] Unit tests pass
- [ ] Documentation updated
- [x] Travis build passed
