### PR TITLE
810 High CPU in combination with openjdk11 and log4j2

### DIFF
--- a/core/src/main/java/com/github/dozermapper/core/MappingProcessor.java
+++ b/core/src/main/java/com/github/dozermapper/core/MappingProcessor.java
@@ -80,7 +80,7 @@ import static com.github.dozermapper.core.util.DozerConstants.ITERATE;
  */
 public class MappingProcessor implements Mapper {
 
-    private final Logger log = LoggerFactory.getLogger(MappingProcessor.class);
+    private static final Logger log = LoggerFactory.getLogger(MappingProcessor.class);
 
     private final ClassMappings classMappings;
     private final Configuration globalConfiguration;

--- a/core/src/main/java/com/github/dozermapper/core/util/LogMsgFactory.java
+++ b/core/src/main/java/com/github/dozermapper/core/util/LogMsgFactory.java
@@ -29,7 +29,7 @@ import org.slf4j.LoggerFactory;
  */
 public final class LogMsgFactory {
 
-    private final Logger log = LoggerFactory.getLogger(LogMsgFactory.class);
+    private static final Logger log = LoggerFactory.getLogger(LogMsgFactory.class);
 
     public String createFieldMappingErrorMsg(Object srcObj, FieldMap fieldMapping, Object srcFieldValue, Object destObj) {
         String srcClassName = null;


### PR DESCRIPTION
## Issue link
_All PRs **MUST** have a corresponding issue linked and issue number in PR name. i.e.:_

        [ISSUE: 810] High CPU in combination with openjdk11 and log4j2

## Purpose
When using OpenJDK11 and log4j2 in combination with dozer mapper causes high cpu while stackwalking. Several issues have been reported in on the openjdk combination with log4j2.

## Approach
Dozer creates loggers each time the map() function is called in 'MappingProcessor' and 'LogMsgFactory'. This causes stackwalking which drastically decreases performance. 
While running a small test mapping objects, mapping times improved by 50%.

## Open Questions and Pre-Merge TODOs
- [x] Issue created: https://github.com/DozerMapper/dozer/issues/810
- [ ] Unit tests pass
- [ ] Documentation updated
- [ ] Travis build passed
