### PR TITLE
added jakarta support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Supports:
 * Java 11
 * JAXB 4
 
+**Spring Boot started/autoconfiguration have not yet migrated to support Spring Boot 3** 
+
 ## Project Activity
 The project is currently not active and will more than likely be deprecated in the future. If you are looking to use Dozer
 on a greenfield project, we would discourage that. If you have been using Dozer for a while, we would suggest you start to think about migrating

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Supports:
 * Java 11
 * JAXB 4
 
+To build `mvn clean install`
+
 **Spring Boot starter/autoconfiguration have not yet migrated to support Spring Boot 3** 
 
 ## Project Activity

--- a/README.md
+++ b/README.md
@@ -4,17 +4,6 @@
 
 # Dozer
 
-## Fork info 
-The project was migrated to jakarta to unblock migration to Spring Boot 3
-
-Supports:
-* Java 11
-* JAXB 4
-
-To build `mvn clean install`
-
-**Spring Boot starter/autoconfiguration have not yet migrated to support Spring Boot 3** 
-
 ## Project Activity
 The project is currently not active and will more than likely be deprecated in the future. If you are looking to use Dozer
 on a greenfield project, we would discourage that. If you have been using Dozer for a while, we would suggest you start to think about migrating

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Supports:
 * Java 11
 * JAXB 4
 
-**Spring Boot started/autoconfiguration have not yet migrated to support Spring Boot 3** 
+**Spring Boot starter/autoconfiguration have not yet migrated to support Spring Boot 3** 
 
 ## Project Activity
 The project is currently not active and will more than likely be deprecated in the future. If you are looking to use Dozer

--- a/README.md
+++ b/README.md
@@ -3,6 +3,14 @@
 [![License](https://img.shields.io/hexpm/l/plug.svg?maxAge=2592000)]()
 
 # Dozer
+
+## Fork info 
+The project was migrated to jakarta to unblock migration to Spring Boot 3
+
+Supports:
+* Java 11
+* JAXB 4
+
 ## Project Activity
 The project is currently not active and will more than likely be deprecated in the future. If you are looking to use Dozer
 on a greenfield project, we would discourage that. If you have been using Dozer for a while, we would suggest you start to think about migrating

--- a/bom-dependencies/pom.xml
+++ b/bom-dependencies/pom.xml
@@ -38,14 +38,14 @@
         <commons-beanutils.version>1.9.4</commons-beanutils.version>
         <commons-lang3.version>3.7</commons-lang3.version>
         <commons-io.version>2.7</commons-io.version>
-        <javax.el.version>3.0.0</javax.el.version>
+        <jakarta.el.version>4.0.0</jakarta.el.version>
         <felix.version>5.6.8</felix.version>
-        <jaxb-runtime.version>2.4.0-b180830.0438</jaxb-runtime.version>
+        <jaxb.version>4.0.3</jaxb.version>
         <guava.version>22.0</guava.version>
         <hamcrest-all.version>1.3</hamcrest-all.version>
         <hibernate-core.version>5.6.8.Final</hibernate-core.version>
         <jackson-dataformat.version>2.10.1</jackson-dataformat.version>
-        <javax.inject.version>1</javax.inject.version>
+        <jakarta.inject.version>2.0.1</jakarta.inject.version>
         <javassist.version>3.24.0-GA</javassist.version>
         <jmh.version>1.19</jmh.version>
         <junit5-vintage.version>5.1.0</junit5-vintage.version>
@@ -65,6 +65,13 @@
     <dependencyManagement>
         <!-- Dependency; alphabetical order -->
         <dependencies>
+            <dependency>
+                <groupId>org.glassfish.jaxb</groupId>
+                <artifactId>jaxb-bom</artifactId>
+                <version>${jaxb.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
             <dependency>
                 <groupId>cglib</groupId>
                 <artifactId>cglib-nodep</artifactId>
@@ -97,24 +104,14 @@
                 <version>${commons-io.version}</version>
             </dependency>
             <dependency>
-                <groupId>javax.el</groupId>
-                <artifactId>javax.el-api</artifactId>
-                <version>${javax.el.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.glassfish</groupId>
-                <artifactId>javax.el</artifactId>
-                <version>${javax.el.version}</version>
+              <groupId>org.glassfish</groupId>
+              <artifactId>jakarta.el</artifactId>
+                <version>${jakarta.el.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>org.apache.felix.framework</artifactId>
                 <version>${felix.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.glassfish.jaxb</groupId>
-                <artifactId>jaxb-runtime</artifactId>
-                <version>${jaxb-runtime.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.hamcrest</groupId>
@@ -147,9 +144,9 @@
                 <version>${jackson-dataformat.version}</version>
             </dependency>
             <dependency>
-                <groupId>javax.inject</groupId>
-                <artifactId>javax.inject</artifactId>
-                <version>${javax.inject.version}</version>
+              <groupId>jakarta.inject</groupId>
+              <artifactId>jakarta.inject-api</artifactId>
+              <version>${jakarta.inject.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.javassist</groupId>

--- a/bom-dependencies/pom.xml
+++ b/bom-dependencies/pom.xml
@@ -104,8 +104,8 @@
                 <version>${commons-io.version}</version>
             </dependency>
             <dependency>
-              <groupId>org.glassfish</groupId>
-              <artifactId>jakarta.el</artifactId>
+                <groupId>org.glassfish</groupId>
+                <artifactId>jakarta.el</artifactId>
                 <version>${jakarta.el.version}</version>
             </dependency>
             <dependency>
@@ -144,9 +144,9 @@
                 <version>${jackson-dataformat.version}</version>
             </dependency>
             <dependency>
-              <groupId>jakarta.inject</groupId>
-              <artifactId>jakarta.inject-api</artifactId>
-              <version>${jakarta.inject.version}</version>
+                <groupId>jakarta.inject</groupId>
+                <artifactId>jakarta.inject-api</artifactId>
+                <version>${jakarta.inject.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.javassist</groupId>

--- a/building-tools/src/main/resources/loose-checkstyle.xml
+++ b/building-tools/src/main/resources/loose-checkstyle.xml
@@ -68,10 +68,10 @@
         <module name="AvoidStarImport"/>
         <module name="RedundantImport"/>
         <module name="UnusedImports"/>
-        <module name="ImportOrder">
-            <property name="groups" value="java,javax,org.w3c,org.xml"/>
-            <property name="ordered" value="true"/>
-        </module>
+<!--        <module name="ImportOrder">-->
+<!--            <property name="groups" value="java,javax,org.w3c,org.xml"/>-->
+<!--            <property name="ordered" value="true"/>-->
+<!--        </module>-->
 
         <!-- Modifier Checks -->
         <module name="ModifierOrder"/>

--- a/building-tools/src/main/resources/loose-checkstyle.xml
+++ b/building-tools/src/main/resources/loose-checkstyle.xml
@@ -68,10 +68,10 @@
         <module name="AvoidStarImport"/>
         <module name="RedundantImport"/>
         <module name="UnusedImports"/>
-<!--        <module name="ImportOrder">-->
-<!--            <property name="groups" value="java,javax,org.w3c,org.xml"/>-->
-<!--            <property name="ordered" value="true"/>-->
-<!--        </module>-->
+        <module name="ImportOrder">
+            <property name="groups" value="java,jakarta,javax,org.w3c,org.xml"/>
+            <property name="ordered" value="true"/>
+        </module>
 
         <!-- Modifier Checks -->
         <module name="ModifierOrder"/>

--- a/building-tools/src/main/resources/strict-checkstyle.xml
+++ b/building-tools/src/main/resources/strict-checkstyle.xml
@@ -69,7 +69,7 @@
         <module name="RedundantImport"/>
         <module name="UnusedImports"/>
         <module name="ImportOrder">
-            <property name="groups" value="java,javax,org.w3c,org.xml"/>
+            <property name="groups" value="java,jakarta,javax,org.w3c,org.xml"/>
             <property name="ordered" value="true"/>
         </module>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -283,52 +283,10 @@
 
     <profiles>
         <profile>
-            <id>jdk8-build</id>
+            <id>jdk11-and-above-build</id>
             <activation>
-                <jdk>1.8</jdk>
+                <jdk>[11,)</jdk>
             </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>jaxb2-maven-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>schemagen</id>
-                                <phase>generate-resources</phase>
-                                <goals>
-                                    <goal>schemagen</goal>
-                                </goals>
-                                <configuration>
-                                    <workDirectory>${project.build.directory}/generated-resources/schemagen</workDirectory>
-                                    <includes>
-                                        com/github/dozermapper/core/builder/model/jaxb/**
-                                    </includes>
-                                    <transformSchemas>
-                                        <transformSchema>
-                                            <uri>http://dozermapper.github.io/schema/bean-mapping</uri>
-                                            <toFile>bean-mapping.xsd</toFile>
-                                        </transformSchema>
-                                    </transformSchemas>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <profile>
-            <id>jdk9-and-above-build</id>
-            <activation>
-                <jdk>[9,)</jdk>
-            </activation>
-            <properties>
-                <!-- Remove once servicemix jaxb-2.3 is released: https://issues.apache.org/jira/browse/SM-3854 -->
-                <osgi.additional.Import-Package>
-                    jakarta.xml.bind;version="[2.2,3)",
-                    jakarta.xml.bind.annotation;version="[2.2,3)"
-                </osgi.additional.Import-Package>
-            </properties>
             <dependencies>
                 <dependency>
                     <groupId>org.glassfish.jaxb</groupId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -55,52 +55,58 @@
         <maven-resources/>
     </properties>
 
-    <dependencies>
-        <!-- Commons -->
-        <dependency>
-            <groupId>commons-beanutils</groupId>
-            <artifactId>commons-beanutils</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>commons-logging</groupId>
-                    <artifactId>commons-logging</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>commons-io</groupId>
-            <artifactId>commons-io</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.javassist</groupId>
-            <artifactId>javassist</artifactId>
-            <scope>provided</scope>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-            <scope>provided</scope>
-        </dependency>
-
+  <dependencies>
+    	<!-- Commons -->
+      <dependency>
+        <groupId>commons-beanutils</groupId>
+        <artifactId>commons-beanutils</artifactId>
+        <exclusions>
+          <exclusion>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-lang3</artifactId>
+      </dependency>
+      <dependency>
+        <groupId>commons-io</groupId>
+        <artifactId>commons-io</artifactId>
+      </dependency>
+      <dependency>
+        <groupId>org.javassist</groupId>
+        <artifactId>javassist</artifactId>
+        <scope>provided</scope>
+        <optional>true</optional>
+      </dependency>
+      <dependency>
+        <groupId>org.projectlombok</groupId>
+        <artifactId>lombok</artifactId>
+        <scope>provided</scope>
+      </dependency>
+     <!--JAXB-API-->
+      <dependency>
+        <groupId>jakarta.xml.bind</groupId>
+        <artifactId>jakarta.xml.bind-api</artifactId>
+      </dependency>
+      <dependency>
+        <groupId>org.glassfish.jaxb</groupId>
+        <artifactId>jaxb-runtime</artifactId>
+        <scope>runtime</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.glassfish.jaxb</groupId>
+        <artifactId>jaxb-xjc</artifactId>
+      </dependency>
         <!-- EL -->
-        <dependency>
-            <groupId>javax.el</groupId>
-            <artifactId>javax.el-api</artifactId>
-            <scope>provided</scope>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish</groupId>
-            <artifactId>javax.el</artifactId>
-            <scope>provided</scope>
-            <optional>true</optional>
-        </dependency>
-
+      <dependency>
+        <groupId>org.glassfish</groupId>
+        <artifactId>jakarta.el</artifactId>
+        <scope>provided</scope>
+        <optional>true</optional>
+      </dependency>
         <!-- YAML -->
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
@@ -276,41 +282,41 @@
     </build>
 
     <profiles>
-        <profile>
-            <id>jdk8-build</id>
-            <activation>
-                <jdk>1.8</jdk>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>jaxb2-maven-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>schemagen</id>
-                                <phase>generate-resources</phase>
-                                <goals>
-                                    <goal>schemagen</goal>
-                                </goals>
-                                <configuration>
-                                    <workDirectory>${project.build.directory}/generated-resources/schemagen</workDirectory>
-                                    <includes>
-                                        com/github/dozermapper/core/builder/model/jaxb/**
-                                    </includes>
-                                    <transformSchemas>
-                                        <transformSchema>
-                                            <uri>http://dozermapper.github.io/schema/bean-mapping</uri>
-                                            <toFile>bean-mapping.xsd</toFile>
-                                        </transformSchema>
-                                    </transformSchemas>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
+<!--        <profile>-->
+<!--            <id>jdk8-build</id>-->
+<!--            <activation>-->
+<!--                <jdk>1.8</jdk>-->
+<!--            </activation>-->
+<!--            <build>-->
+<!--                <plugins>-->
+<!--                    <plugin>-->
+<!--                        <groupId>org.codehaus.mojo</groupId>-->
+<!--                        <artifactId>jaxb2-maven-plugin</artifactId>-->
+<!--                        <executions>-->
+<!--                            <execution>-->
+<!--                                <id>schemagen</id>-->
+<!--                                <phase>generate-resources</phase>-->
+<!--                                <goals>-->
+<!--                                    <goal>schemagen</goal>-->
+<!--                                </goals>-->
+<!--                                <configuration>-->
+<!--                                    <workDirectory>${project.build.directory}/generated-resources/schemagen</workDirectory>-->
+<!--                                    <includes>-->
+<!--                                        com/github/dozermapper/core/builder/model/jaxb/**-->
+<!--                                    </includes>-->
+<!--                                    <transformSchemas>-->
+<!--                                        <transformSchema>-->
+<!--                                            <uri>http://dozermapper.github.io/schema/bean-mapping</uri>-->
+<!--                                            <toFile>bean-mapping.xsd</toFile>-->
+<!--                                        </transformSchema>-->
+<!--                                    </transformSchemas>-->
+<!--                                </configuration>-->
+<!--                            </execution>-->
+<!--                        </executions>-->
+<!--                    </plugin>-->
+<!--                </plugins>-->
+<!--            </build>-->
+<!--        </profile>-->
         <profile>
             <id>jdk9-and-above-build</id>
             <activation>
@@ -319,8 +325,8 @@
             <properties>
                 <!-- Remove once servicemix jaxb-2.3 is released: https://issues.apache.org/jira/browse/SM-3854 -->
                 <osgi.additional.Import-Package>
-                    javax.xml.bind;version="[2.2,3)",
-                    javax.xml.bind.annotation;version="[2.2,3)"
+                    jakarta.xml.bind;version="[2.2,3)",
+                    jakarta.xml.bind.annotation;version="[2.2,3)"
                 </osgi.additional.Import-Package>
             </properties>
             <dependencies>
@@ -343,9 +349,11 @@
                                 </goals>
                                 <configuration>
                                     <workDirectory>${project.build.directory}/generated-resources/schemagen</workDirectory>
-                                    <includes>
-                                        com/github/dozermapper/core/builder/model/jaxb/**
-                                    </includes>
+                                    <sources>
+                                      <source>
+                                        src/main/java/com/github/dozermapper/core/builder/model/jaxb
+                                      </source>
+                                    </sources>
                                 </configuration>
                             </execution>
                         </executions>
@@ -353,7 +361,7 @@
                             <dependency>
                                 <groupId>org.glassfish.jaxb</groupId>
                                 <artifactId>jaxb-runtime</artifactId>
-                                <version>2.4.0-b180830.0438</version>
+                                <version>4.0.3</version>
                             </dependency>
                         </dependencies>
                     </plugin>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -282,41 +282,41 @@
     </build>
 
     <profiles>
-<!--        <profile>-->
-<!--            <id>jdk8-build</id>-->
-<!--            <activation>-->
-<!--                <jdk>1.8</jdk>-->
-<!--            </activation>-->
-<!--            <build>-->
-<!--                <plugins>-->
-<!--                    <plugin>-->
-<!--                        <groupId>org.codehaus.mojo</groupId>-->
-<!--                        <artifactId>jaxb2-maven-plugin</artifactId>-->
-<!--                        <executions>-->
-<!--                            <execution>-->
-<!--                                <id>schemagen</id>-->
-<!--                                <phase>generate-resources</phase>-->
-<!--                                <goals>-->
-<!--                                    <goal>schemagen</goal>-->
-<!--                                </goals>-->
-<!--                                <configuration>-->
-<!--                                    <workDirectory>${project.build.directory}/generated-resources/schemagen</workDirectory>-->
-<!--                                    <includes>-->
-<!--                                        com/github/dozermapper/core/builder/model/jaxb/**-->
-<!--                                    </includes>-->
-<!--                                    <transformSchemas>-->
-<!--                                        <transformSchema>-->
-<!--                                            <uri>http://dozermapper.github.io/schema/bean-mapping</uri>-->
-<!--                                            <toFile>bean-mapping.xsd</toFile>-->
-<!--                                        </transformSchema>-->
-<!--                                    </transformSchemas>-->
-<!--                                </configuration>-->
-<!--                            </execution>-->
-<!--                        </executions>-->
-<!--                    </plugin>-->
-<!--                </plugins>-->
-<!--            </build>-->
-<!--        </profile>-->
+        <profile>
+            <id>jdk8-build</id>
+            <activation>
+                <jdk>1.8</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>jaxb2-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>schemagen</id>
+                                <phase>generate-resources</phase>
+                                <goals>
+                                    <goal>schemagen</goal>
+                                </goals>
+                                <configuration>
+                                    <workDirectory>${project.build.directory}/generated-resources/schemagen</workDirectory>
+                                    <includes>
+                                        com/github/dozermapper/core/builder/model/jaxb/**
+                                    </includes>
+                                    <transformSchemas>
+                                        <transformSchema>
+                                            <uri>http://dozermapper.github.io/schema/bean-mapping</uri>
+                                            <toFile>bean-mapping.xsd</toFile>
+                                        </transformSchema>
+                                    </transformSchemas>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
         <profile>
             <id>jdk9-and-above-build</id>
             <activation>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -43,7 +43,8 @@
         <osgi.Export-Package>com.github.dozermapper.core.*</osgi.Export-Package>
         <!-- ServiceLoader Capability -->
         <osgi.Require-Capability>
-            osgi.serviceloader; filter:="(osgi.serviceloader=com.github.dozermapper.core.DozerModule)";cardinality:=multiple;resolution:=optional,
+            osgi.serviceloader;
+            filter:="(osgi.serviceloader=com.github.dozermapper.core.DozerModule)";cardinality:=multiple;resolution:=optional,
             osgi.extender; filter:="(osgi.extender=osgi.serviceloader.processor)";resolution:=optional
         </osgi.Require-Capability>
         <osgi.SPI-Consumer>*</osgi.SPI-Consumer>
@@ -55,58 +56,58 @@
         <maven-resources/>
     </properties>
 
-  <dependencies>
-    	<!-- Commons -->
-      <dependency>
-        <groupId>commons-beanutils</groupId>
-        <artifactId>commons-beanutils</artifactId>
-        <exclusions>
-          <exclusion>
-            <groupId>commons-logging</groupId>
-            <artifactId>commons-logging</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.commons</groupId>
-        <artifactId>commons-lang3</artifactId>
-      </dependency>
-      <dependency>
-        <groupId>commons-io</groupId>
-        <artifactId>commons-io</artifactId>
-      </dependency>
-      <dependency>
-        <groupId>org.javassist</groupId>
-        <artifactId>javassist</artifactId>
-        <scope>provided</scope>
-        <optional>true</optional>
-      </dependency>
-      <dependency>
-        <groupId>org.projectlombok</groupId>
-        <artifactId>lombok</artifactId>
-        <scope>provided</scope>
-      </dependency>
-     <!--JAXB-API-->
-      <dependency>
-        <groupId>jakarta.xml.bind</groupId>
-        <artifactId>jakarta.xml.bind-api</artifactId>
-      </dependency>
-      <dependency>
-        <groupId>org.glassfish.jaxb</groupId>
-        <artifactId>jaxb-runtime</artifactId>
-        <scope>runtime</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.glassfish.jaxb</groupId>
-        <artifactId>jaxb-xjc</artifactId>
-      </dependency>
+    <dependencies>
+        <!-- Commons -->
+        <dependency>
+            <groupId>commons-beanutils</groupId>
+            <artifactId>commons-beanutils</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.javassist</groupId>
+            <artifactId>javassist</artifactId>
+            <scope>provided</scope>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <!--JAXB-API-->
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-xjc</artifactId>
+        </dependency>
         <!-- EL -->
-      <dependency>
-        <groupId>org.glassfish</groupId>
-        <artifactId>jakarta.el</artifactId>
-        <scope>provided</scope>
-        <optional>true</optional>
-      </dependency>
+        <dependency>
+            <groupId>org.glassfish</groupId>
+            <artifactId>jakarta.el</artifactId>
+            <scope>provided</scope>
+            <optional>true</optional>
+        </dependency>
         <!-- YAML -->
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
@@ -306,11 +307,12 @@
                                     <goal>schemagen</goal>
                                 </goals>
                                 <configuration>
-                                    <workDirectory>${project.build.directory}/generated-resources/schemagen</workDirectory>
+                                    <workDirectory>${project.build.directory}/generated-resources/schemagen
+                                    </workDirectory>
                                     <sources>
-                                      <source>
-                                        src/main/java/com/github/dozermapper/core/builder/model/jaxb
-                                      </source>
+                                        <source>
+                                            src/main/java/com/github/dozermapper/core/builder/model/jaxb
+                                        </source>
                                     </sources>
                                 </configuration>
                             </execution>
@@ -333,9 +335,10 @@
                                 <configuration>
                                     <target>
                                         <echo>Copying XSD schema to be included in JAR</echo>
-                                        <replace file="${project.build.directory}/generated-resources/schemagen/schema1.xsd"
-                                                 token="xmlns:xs=&quot;http://www.w3.org/2001/XMLSchema&quot;"
-                                                 value="xmlns=&quot;http://www.w3.org/2001/XMLSchema&quot; xmlns:xs=&quot;http://www.w3.org/2001/XMLSchema&quot;"/>
+                                        <replace
+                                                file="${project.build.directory}/generated-resources/schemagen/schema1.xsd"
+                                                token="xmlns:xs=&quot;http://www.w3.org/2001/XMLSchema&quot;"
+                                                value="xmlns=&quot;http://www.w3.org/2001/XMLSchema&quot; xmlns:xs=&quot;http://www.w3.org/2001/XMLSchema&quot;"/>
                                         <move file="${project.build.directory}/generated-resources/schemagen/schema1.xsd"
                                               tofile="${project.build.directory}/generated-resources/schemagen/bean-mapping.xsd"/>
                                     </target>

--- a/core/src/main/java/com/github/dozermapper/core/MappingProcessor.java
+++ b/core/src/main/java/com/github/dozermapper/core/MappingProcessor.java
@@ -255,9 +255,9 @@ public class MappingProcessor implements Mapper {
      */
     private void mapToDestObject(ClassMap classMap, Object srcObj, Object destObj, boolean bypassSuperMappings, String mapId) {
         Object result = destObj;
-        if (javax.xml.bind.JAXBElement.class.isAssignableFrom(destObj.getClass())) {
-            classMap = getClassMap(srcObj.getClass(), javax.xml.bind.JAXBElement.class.cast(destObj).getDeclaredType(), mapId);
-            result = javax.xml.bind.JAXBElement.class.cast(destObj).getValue();
+        if (jakarta.xml.bind.JAXBElement.class.isAssignableFrom(destObj.getClass())) {
+            classMap = getClassMap(srcObj.getClass(), jakarta.xml.bind.JAXBElement.class.cast(destObj).getDeclaredType(), mapId);
+            result = jakarta.xml.bind.JAXBElement.class.cast(destObj).getValue();
         }
 
         map(classMap, srcObj, result, bypassSuperMappings, new ArrayList<>(), mapId);

--- a/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/AllowedExceptionsDefinition.java
+++ b/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/AllowedExceptionsDefinition.java
@@ -18,12 +18,12 @@ package com.github.dozermapper.core.builder.model.jaxb;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlTransient;
-import javax.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlTransient;
+import jakarta.xml.bind.annotation.XmlType;
 
 import com.github.dozermapper.core.config.BeanContainer;
 import com.github.dozermapper.core.util.MappingUtils;
@@ -87,5 +87,17 @@ public class AllowedExceptionsDefinition {
 
     public ConfigurationDefinition end() {
         return parent;
+    }
+
+    public ConfigurationDefinition getParent() {
+        return parent;
+    }
+
+    public List<String> getExceptions() {
+        return exceptions;
+    }
+
+    protected void setExceptions(List<String> exceptions) {
+        this.exceptions = exceptions;
     }
 }

--- a/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/AllowedExceptionsDefinition.java
+++ b/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/AllowedExceptionsDefinition.java
@@ -15,26 +15,21 @@
  */
 package com.github.dozermapper.core.builder.model.jaxb;
 
-import java.util.ArrayList;
-import java.util.List;
-
+import com.github.dozermapper.core.config.BeanContainer;
+import com.github.dozermapper.core.util.MappingUtils;
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import jakarta.xml.bind.annotation.XmlTransient;
 import jakarta.xml.bind.annotation.XmlType;
-
-import com.github.dozermapper.core.config.BeanContainer;
-import com.github.dozermapper.core.util.MappingUtils;
-import lombok.AccessLevel;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.Setter;
 import lombok.ToString;
 
-@Getter
-@Setter(AccessLevel.PROTECTED)
+//@Getter
+//@Setter(AccessLevel.PROTECTED)
 @ToString
 @EqualsAndHashCode
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/AllowedExceptionsDefinition.java
+++ b/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/AllowedExceptionsDefinition.java
@@ -17,24 +17,17 @@ package com.github.dozermapper.core.builder.model.jaxb;
 
 import java.util.ArrayList;
 import java.util.List;
-
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import jakarta.xml.bind.annotation.XmlTransient;
 import jakarta.xml.bind.annotation.XmlType;
-
 import com.github.dozermapper.core.config.BeanContainer;
 import com.github.dozermapper.core.util.MappingUtils;
-import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.Setter;
 import lombok.ToString;
 
-@Getter
-@Setter(AccessLevel.PROTECTED)
 @ToString
 @EqualsAndHashCode
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/AllowedExceptionsDefinition.java
+++ b/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/AllowedExceptionsDefinition.java
@@ -15,21 +15,26 @@
  */
 package com.github.dozermapper.core.builder.model.jaxb;
 
-import com.github.dozermapper.core.config.BeanContainer;
-import com.github.dozermapper.core.util.MappingUtils;
+import java.util.ArrayList;
+import java.util.List;
+
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import jakarta.xml.bind.annotation.XmlTransient;
 import jakarta.xml.bind.annotation.XmlType;
-import java.util.ArrayList;
-import java.util.List;
+
+import com.github.dozermapper.core.config.BeanContainer;
+import com.github.dozermapper.core.util.MappingUtils;
+import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
 import lombok.ToString;
 
-//@Getter
-//@Setter(AccessLevel.PROTECTED)
+@Getter
+@Setter(AccessLevel.PROTECTED)
 @ToString
 @EqualsAndHashCode
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/ClassDefinition.java
+++ b/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/ClassDefinition.java
@@ -15,15 +15,19 @@
  */
 package com.github.dozermapper.core.builder.model.jaxb;
 
-import com.github.dozermapper.core.classmap.DozerClass;
-import com.github.dozermapper.core.config.BeanContainer;
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlAttribute;
 import jakarta.xml.bind.annotation.XmlTransient;
 import jakarta.xml.bind.annotation.XmlType;
 import jakarta.xml.bind.annotation.XmlValue;
+
+import com.github.dozermapper.core.classmap.DozerClass;
+import com.github.dozermapper.core.config.BeanContainer;
+import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
 import lombok.ToString;
 
 /**
@@ -55,8 +59,8 @@ import lombok.ToString;
  * is-accessible Indicates whether Dozer bypasses getter/setter methods and accesses the field directly. This will typically be set to "false". The default value is
  * "false". If set to "true", the getter/setter methods will NOT be invoked. You would want to set this to "true" if the field is lacking a getter or setter method.
  */
-//@Getter
-//@Setter(AccessLevel.PROTECTED)
+@Getter
+@Setter(AccessLevel.PROTECTED)
 @ToString
 @EqualsAndHashCode
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/ClassDefinition.java
+++ b/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/ClassDefinition.java
@@ -15,12 +15,12 @@
  */
 package com.github.dozermapper.core.builder.model.jaxb;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlTransient;
-import javax.xml.bind.annotation.XmlType;
-import javax.xml.bind.annotation.XmlValue;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlTransient;
+import jakarta.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.XmlValue;
 
 import com.github.dozermapper.core.classmap.DozerClass;
 import com.github.dozermapper.core.config.BeanContainer;
@@ -196,5 +196,93 @@ public class ClassDefinition {
         dozerClass.setSkipConstructor(skipConstructor);
 
         return dozerClass;
+    }
+
+    public MappingDefinition getParentMappingDefinition() {
+        return parentMappingDefinition;
+    }
+
+    public ConverterTypeDefinition getParentConverterTypeDefinition() {
+        return parentConverterTypeDefinition;
+    }
+
+    public String getClazz() {
+        return clazz;
+    }
+
+    protected void setClazz(String clazz) {
+        this.clazz = clazz;
+    }
+
+    public String getBeanFactory() {
+        return beanFactory;
+    }
+
+    protected void setBeanFactory(String beanFactory) {
+        this.beanFactory = beanFactory;
+    }
+
+    public String getFactoryBeanId() {
+        return factoryBeanId;
+    }
+
+    protected void setFactoryBeanId(String factoryBeanId) {
+        this.factoryBeanId = factoryBeanId;
+    }
+
+    public String getMapSetMethod() {
+        return mapSetMethod;
+    }
+
+    protected void setMapSetMethod(String mapSetMethod) {
+        this.mapSetMethod = mapSetMethod;
+    }
+
+    public String getMapGetMethod() {
+        return mapGetMethod;
+    }
+
+    protected void setMapGetMethod(String mapGetMethod) {
+        this.mapGetMethod = mapGetMethod;
+    }
+
+    public String getCreateMethod() {
+        return createMethod;
+    }
+
+    protected void setCreateMethod(String createMethod) {
+        this.createMethod = createMethod;
+    }
+
+    public Boolean getMapNull() {
+        return mapNull;
+    }
+
+    protected void setMapNull(Boolean mapNull) {
+        this.mapNull = mapNull;
+    }
+
+    public Boolean getMapEmptyString() {
+        return mapEmptyString;
+    }
+
+    protected void setMapEmptyString(Boolean mapEmptyString) {
+        this.mapEmptyString = mapEmptyString;
+    }
+
+    public Boolean getIsAccessible() {
+        return isAccessible;
+    }
+
+    protected void setIsAccessible(Boolean accessible) {
+        isAccessible = accessible;
+    }
+
+    public Boolean getSkipConstructor() {
+        return skipConstructor;
+    }
+
+    protected void setSkipConstructor(Boolean skipConstructor) {
+        this.skipConstructor = skipConstructor;
     }
 }

--- a/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/ClassDefinition.java
+++ b/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/ClassDefinition.java
@@ -15,19 +15,15 @@
  */
 package com.github.dozermapper.core.builder.model.jaxb;
 
+import com.github.dozermapper.core.classmap.DozerClass;
+import com.github.dozermapper.core.config.BeanContainer;
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlAttribute;
 import jakarta.xml.bind.annotation.XmlTransient;
 import jakarta.xml.bind.annotation.XmlType;
 import jakarta.xml.bind.annotation.XmlValue;
-
-import com.github.dozermapper.core.classmap.DozerClass;
-import com.github.dozermapper.core.config.BeanContainer;
-import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.Setter;
 import lombok.ToString;
 
 /**
@@ -59,8 +55,8 @@ import lombok.ToString;
  * is-accessible Indicates whether Dozer bypasses getter/setter methods and accesses the field directly. This will typically be set to "false". The default value is
  * "false". If set to "true", the getter/setter methods will NOT be invoked. You would want to set this to "true" if the field is lacking a getter or setter method.
  */
-@Getter
-@Setter(AccessLevel.PROTECTED)
+//@Getter
+//@Setter(AccessLevel.PROTECTED)
 @ToString
 @EqualsAndHashCode
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/ClassDefinition.java
+++ b/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/ClassDefinition.java
@@ -21,13 +21,9 @@ import jakarta.xml.bind.annotation.XmlAttribute;
 import jakarta.xml.bind.annotation.XmlTransient;
 import jakarta.xml.bind.annotation.XmlType;
 import jakarta.xml.bind.annotation.XmlValue;
-
 import com.github.dozermapper.core.classmap.DozerClass;
 import com.github.dozermapper.core.config.BeanContainer;
-import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.Setter;
 import lombok.ToString;
 
 /**
@@ -59,8 +55,6 @@ import lombok.ToString;
  * is-accessible Indicates whether Dozer bypasses getter/setter methods and accesses the field directly. This will typically be set to "false". The default value is
  * "false". If set to "true", the getter/setter methods will NOT be invoked. You would want to set this to "true" if the field is lacking a getter or setter method.
  */
-@Getter
-@Setter(AccessLevel.PROTECTED)
 @ToString
 @EqualsAndHashCode
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/ConfigurationDefinition.java
+++ b/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/ConfigurationDefinition.java
@@ -15,19 +15,24 @@
  */
 package com.github.dozermapper.core.builder.model.jaxb;
 
-import com.github.dozermapper.core.classmap.Configuration;
-import com.github.dozermapper.core.classmap.CopyByReference;
-import com.github.dozermapper.core.classmap.RelationshipType;
-import com.github.dozermapper.core.config.BeanContainer;
-import com.github.dozermapper.core.util.DozerConstants;
+import java.util.List;
+
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import jakarta.xml.bind.annotation.XmlTransient;
 import jakarta.xml.bind.annotation.XmlType;
-import java.util.List;
+
+import com.github.dozermapper.core.classmap.Configuration;
+import com.github.dozermapper.core.classmap.CopyByReference;
+import com.github.dozermapper.core.classmap.RelationshipType;
+import com.github.dozermapper.core.config.BeanContainer;
+import com.github.dozermapper.core.util.DozerConstants;
+import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
 import lombok.ToString;
 
 /**
@@ -64,8 +69,8 @@ import lombok.ToString;
  * <p>
  * copy-by-references Indicates which class types should always be copied by reference
  */
-//@Getter
-//@Setter(AccessLevel.PROTECTED)
+@Getter
+@Setter(AccessLevel.PROTECTED)
 @ToString
 @EqualsAndHashCode
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/ConfigurationDefinition.java
+++ b/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/ConfigurationDefinition.java
@@ -16,23 +16,18 @@
 package com.github.dozermapper.core.builder.model.jaxb;
 
 import java.util.List;
-
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import jakarta.xml.bind.annotation.XmlTransient;
 import jakarta.xml.bind.annotation.XmlType;
-
 import com.github.dozermapper.core.classmap.Configuration;
 import com.github.dozermapper.core.classmap.CopyByReference;
 import com.github.dozermapper.core.classmap.RelationshipType;
 import com.github.dozermapper.core.config.BeanContainer;
 import com.github.dozermapper.core.util.DozerConstants;
-import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.Setter;
 import lombok.ToString;
 
 /**
@@ -69,8 +64,6 @@ import lombok.ToString;
  * <p>
  * copy-by-references Indicates which class types should always be copied by reference
  */
-@Getter
-@Setter(AccessLevel.PROTECTED)
 @ToString
 @EqualsAndHashCode
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/ConfigurationDefinition.java
+++ b/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/ConfigurationDefinition.java
@@ -15,24 +15,19 @@
  */
 package com.github.dozermapper.core.builder.model.jaxb;
 
-import java.util.List;
-
+import com.github.dozermapper.core.classmap.Configuration;
+import com.github.dozermapper.core.classmap.CopyByReference;
+import com.github.dozermapper.core.classmap.RelationshipType;
+import com.github.dozermapper.core.config.BeanContainer;
+import com.github.dozermapper.core.util.DozerConstants;
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import jakarta.xml.bind.annotation.XmlTransient;
 import jakarta.xml.bind.annotation.XmlType;
-
-import com.github.dozermapper.core.classmap.Configuration;
-import com.github.dozermapper.core.classmap.CopyByReference;
-import com.github.dozermapper.core.classmap.RelationshipType;
-import com.github.dozermapper.core.config.BeanContainer;
-import com.github.dozermapper.core.util.DozerConstants;
-import lombok.AccessLevel;
+import java.util.List;
 import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.Setter;
 import lombok.ToString;
 
 /**
@@ -69,8 +64,8 @@ import lombok.ToString;
  * <p>
  * copy-by-references Indicates which class types should always be copied by reference
  */
-@Getter
-@Setter(AccessLevel.PROTECTED)
+//@Getter
+//@Setter(AccessLevel.PROTECTED)
 @ToString
 @EqualsAndHashCode
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/ConfigurationDefinition.java
+++ b/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/ConfigurationDefinition.java
@@ -17,12 +17,12 @@ package com.github.dozermapper.core.builder.model.jaxb;
 
 import java.util.List;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlTransient;
-import javax.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlTransient;
+import jakarta.xml.bind.annotation.XmlType;
 
 import com.github.dozermapper.core.classmap.Configuration;
 import com.github.dozermapper.core.classmap.CopyByReference;
@@ -250,5 +250,113 @@ public class ConfigurationDefinition {
         }
 
         return config;
+    }
+
+    public MappingsDefinition getParent() {
+        return parent;
+    }
+
+    public Boolean getStopOnErrors() {
+        return stopOnErrors;
+    }
+
+    protected void setStopOnErrors(Boolean stopOnErrors) {
+        this.stopOnErrors = stopOnErrors;
+    }
+
+    public String getDateFormat() {
+        return dateFormat;
+    }
+
+    protected void setDateFormat(String dateFormat) {
+        this.dateFormat = dateFormat;
+    }
+
+    public Boolean getWildcard() {
+        return wildcard;
+    }
+
+    protected void setWildcard(Boolean wildcard) {
+        this.wildcard = wildcard;
+    }
+
+    public Boolean getWildcardCaseInsensitive() {
+        return wildcardCaseInsensitive;
+    }
+
+    protected void setWildcardCaseInsensitive(Boolean wildcardCaseInsensitive) {
+        this.wildcardCaseInsensitive = wildcardCaseInsensitive;
+    }
+
+    public Boolean getTrimStrings() {
+        return trimStrings;
+    }
+
+    protected void setTrimStrings(Boolean trimStrings) {
+        this.trimStrings = trimStrings;
+    }
+
+    public Boolean getMapNull() {
+        return mapNull;
+    }
+
+    protected void setMapNull(Boolean mapNull) {
+        this.mapNull = mapNull;
+    }
+
+    public Boolean getMapEmptyString() {
+        return mapEmptyString;
+    }
+
+    protected void setMapEmptyString(Boolean mapEmptyString) {
+        this.mapEmptyString = mapEmptyString;
+    }
+
+    public String getBeanFactory() {
+        return beanFactory;
+    }
+
+    protected void setBeanFactory(String beanFactory) {
+        this.beanFactory = beanFactory;
+    }
+
+    public Relationship getRelationshipType() {
+        return relationshipType;
+    }
+
+    protected void setRelationshipType(Relationship relationshipType) {
+        this.relationshipType = relationshipType;
+    }
+
+    public CustomConvertersDefinition getCustomConverters() {
+        return customConverters;
+    }
+
+    protected void setCustomConverters(CustomConvertersDefinition customConverters) {
+        this.customConverters = customConverters;
+    }
+
+    public CopyByReferencesDefinition getCopyByReferences() {
+        return copyByReferences;
+    }
+
+    protected void setCopyByReferences(CopyByReferencesDefinition copyByReferences) {
+        this.copyByReferences = copyByReferences;
+    }
+
+    public AllowedExceptionsDefinition getAllowedExceptions() {
+        return allowedExceptions;
+    }
+
+    protected void setAllowedExceptions(AllowedExceptionsDefinition allowedExceptions) {
+        this.allowedExceptions = allowedExceptions;
+    }
+
+    public VariablesDefinition getVariables() {
+        return variables;
+    }
+
+    protected void setVariables(VariablesDefinition variables) {
+        this.variables = variables;
     }
 }

--- a/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/ConverterTypeDefinition.java
+++ b/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/ConverterTypeDefinition.java
@@ -15,21 +15,26 @@
  */
 package com.github.dozermapper.core.builder.model.jaxb;
 
-import com.github.dozermapper.core.config.BeanContainer;
-import com.github.dozermapper.core.converters.CustomConverterDescription;
-import com.github.dozermapper.core.util.MappingUtils;
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlAttribute;
 import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlTransient;
 import jakarta.xml.bind.annotation.XmlType;
+
+import com.github.dozermapper.core.config.BeanContainer;
+import com.github.dozermapper.core.converters.CustomConverterDescription;
+import com.github.dozermapper.core.util.MappingUtils;
+import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
 import lombok.ToString;
+
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
-//@Getter
-//@Setter(AccessLevel.PROTECTED)
+@Getter
+@Setter(AccessLevel.PROTECTED)
 @ToString
 @EqualsAndHashCode
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/ConverterTypeDefinition.java
+++ b/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/ConverterTypeDefinition.java
@@ -15,26 +15,21 @@
  */
 package com.github.dozermapper.core.builder.model.jaxb;
 
+import com.github.dozermapper.core.config.BeanContainer;
+import com.github.dozermapper.core.converters.CustomConverterDescription;
+import com.github.dozermapper.core.util.MappingUtils;
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlAttribute;
 import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlTransient;
 import jakarta.xml.bind.annotation.XmlType;
-
-import com.github.dozermapper.core.config.BeanContainer;
-import com.github.dozermapper.core.converters.CustomConverterDescription;
-import com.github.dozermapper.core.util.MappingUtils;
-import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.Setter;
 import lombok.ToString;
-
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
-@Getter
-@Setter(AccessLevel.PROTECTED)
+//@Getter
+//@Setter(AccessLevel.PROTECTED)
 @ToString
 @EqualsAndHashCode
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/ConverterTypeDefinition.java
+++ b/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/ConverterTypeDefinition.java
@@ -21,20 +21,13 @@ import jakarta.xml.bind.annotation.XmlAttribute;
 import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlTransient;
 import jakarta.xml.bind.annotation.XmlType;
-
 import com.github.dozermapper.core.config.BeanContainer;
 import com.github.dozermapper.core.converters.CustomConverterDescription;
 import com.github.dozermapper.core.util.MappingUtils;
-import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.Setter;
 import lombok.ToString;
-
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
-@Getter
-@Setter(AccessLevel.PROTECTED)
 @ToString
 @EqualsAndHashCode
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/ConverterTypeDefinition.java
+++ b/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/ConverterTypeDefinition.java
@@ -15,12 +15,12 @@
  */
 package com.github.dozermapper.core.builder.model.jaxb;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlTransient;
-import javax.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlTransient;
+import jakarta.xml.bind.annotation.XmlType;
 
 import com.github.dozermapper.core.config.BeanContainer;
 import com.github.dozermapper.core.converters.CustomConverterDescription;
@@ -103,5 +103,33 @@ public class ConverterTypeDefinition {
                 .append("classB", classB)
                 .append("type", type)
                 .toString();
+    }
+
+    public CustomConvertersDefinition getParent() {
+        return parent;
+    }
+
+    public ClassDefinition getClassA() {
+        return classA;
+    }
+
+    protected void setClassA(ClassDefinition classA) {
+        this.classA = classA;
+    }
+
+    public ClassDefinition getClassB() {
+        return classB;
+    }
+
+    protected void setClassB(ClassDefinition classB) {
+        this.classB = classB;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    protected void setType(String type) {
+        this.type = type;
     }
 }

--- a/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/CopyByReferencesDefinition.java
+++ b/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/CopyByReferencesDefinition.java
@@ -17,23 +17,16 @@ package com.github.dozermapper.core.builder.model.jaxb;
 
 import java.util.ArrayList;
 import java.util.List;
-
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import jakarta.xml.bind.annotation.XmlTransient;
 import jakarta.xml.bind.annotation.XmlType;
-
 import com.github.dozermapper.core.classmap.CopyByReference;
-import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.Setter;
 import lombok.ToString;
 
-@Getter
-@Setter(AccessLevel.PROTECTED)
 @ToString
 @EqualsAndHashCode
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/CopyByReferencesDefinition.java
+++ b/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/CopyByReferencesDefinition.java
@@ -15,25 +15,20 @@
  */
 package com.github.dozermapper.core.builder.model.jaxb;
 
-import java.util.ArrayList;
-import java.util.List;
-
+import com.github.dozermapper.core.classmap.CopyByReference;
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import jakarta.xml.bind.annotation.XmlTransient;
 import jakarta.xml.bind.annotation.XmlType;
-
-import com.github.dozermapper.core.classmap.CopyByReference;
-import lombok.AccessLevel;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.Setter;
 import lombok.ToString;
 
-@Getter
-@Setter(AccessLevel.PROTECTED)
+//@Getter
+//@Setter(AccessLevel.PROTECTED)
 @ToString
 @EqualsAndHashCode
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/CopyByReferencesDefinition.java
+++ b/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/CopyByReferencesDefinition.java
@@ -15,20 +15,25 @@
  */
 package com.github.dozermapper.core.builder.model.jaxb;
 
-import com.github.dozermapper.core.classmap.CopyByReference;
+import java.util.ArrayList;
+import java.util.List;
+
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import jakarta.xml.bind.annotation.XmlTransient;
 import jakarta.xml.bind.annotation.XmlType;
-import java.util.ArrayList;
-import java.util.List;
+
+import com.github.dozermapper.core.classmap.CopyByReference;
+import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
 import lombok.ToString;
 
-//@Getter
-//@Setter(AccessLevel.PROTECTED)
+@Getter
+@Setter(AccessLevel.PROTECTED)
 @ToString
 @EqualsAndHashCode
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/CopyByReferencesDefinition.java
+++ b/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/CopyByReferencesDefinition.java
@@ -18,12 +18,12 @@ package com.github.dozermapper.core.builder.model.jaxb;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlTransient;
-import javax.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlTransient;
+import jakarta.xml.bind.annotation.XmlType;
 
 import com.github.dozermapper.core.classmap.CopyByReference;
 import lombok.AccessLevel;
@@ -78,5 +78,17 @@ public class CopyByReferencesDefinition {
 
     public ConfigurationDefinition end() {
         return parent;
+    }
+
+    public ConfigurationDefinition getParent() {
+        return parent;
+    }
+
+    public List<String> getCopyByReference() {
+        return copyByReference;
+    }
+
+    protected void setCopyByReference(List<String> copyByReference) {
+        this.copyByReference = copyByReference;
     }
 }

--- a/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/CustomConvertersDefinition.java
+++ b/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/CustomConvertersDefinition.java
@@ -18,12 +18,12 @@ package com.github.dozermapper.core.builder.model.jaxb;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlTransient;
-import javax.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlTransient;
+import jakarta.xml.bind.annotation.XmlType;
 
 import com.github.dozermapper.core.config.BeanContainer;
 import com.github.dozermapper.core.converters.CustomConverterDescription;
@@ -82,5 +82,17 @@ public class CustomConvertersDefinition {
 
     public ConfigurationDefinition end() {
         return parent;
+    }
+
+    public ConfigurationDefinition getParent() {
+        return parent;
+    }
+
+    public List<ConverterTypeDefinition> getConverter() {
+        return converter;
+    }
+
+    protected void setConverter(List<ConverterTypeDefinition> converter) {
+        this.converter = converter;
     }
 }

--- a/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/CustomConvertersDefinition.java
+++ b/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/CustomConvertersDefinition.java
@@ -15,26 +15,21 @@
  */
 package com.github.dozermapper.core.builder.model.jaxb;
 
-import java.util.ArrayList;
-import java.util.List;
-
+import com.github.dozermapper.core.config.BeanContainer;
+import com.github.dozermapper.core.converters.CustomConverterDescription;
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import jakarta.xml.bind.annotation.XmlTransient;
 import jakarta.xml.bind.annotation.XmlType;
-
-import com.github.dozermapper.core.config.BeanContainer;
-import com.github.dozermapper.core.converters.CustomConverterDescription;
-import lombok.AccessLevel;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.Setter;
 import lombok.ToString;
 
-@Getter
-@Setter(AccessLevel.PROTECTED)
+//@Getter
+//@Setter(AccessLevel.PROTECTED)
 @ToString
 @EqualsAndHashCode
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/CustomConvertersDefinition.java
+++ b/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/CustomConvertersDefinition.java
@@ -17,24 +17,17 @@ package com.github.dozermapper.core.builder.model.jaxb;
 
 import java.util.ArrayList;
 import java.util.List;
-
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import jakarta.xml.bind.annotation.XmlTransient;
 import jakarta.xml.bind.annotation.XmlType;
-
 import com.github.dozermapper.core.config.BeanContainer;
 import com.github.dozermapper.core.converters.CustomConverterDescription;
-import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.Setter;
 import lombok.ToString;
 
-@Getter
-@Setter(AccessLevel.PROTECTED)
 @ToString
 @EqualsAndHashCode
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/CustomConvertersDefinition.java
+++ b/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/CustomConvertersDefinition.java
@@ -15,21 +15,26 @@
  */
 package com.github.dozermapper.core.builder.model.jaxb;
 
-import com.github.dozermapper.core.config.BeanContainer;
-import com.github.dozermapper.core.converters.CustomConverterDescription;
+import java.util.ArrayList;
+import java.util.List;
+
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import jakarta.xml.bind.annotation.XmlTransient;
 import jakarta.xml.bind.annotation.XmlType;
-import java.util.ArrayList;
-import java.util.List;
+
+import com.github.dozermapper.core.config.BeanContainer;
+import com.github.dozermapper.core.converters.CustomConverterDescription;
+import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
 import lombok.ToString;
 
-//@Getter
-//@Setter(AccessLevel.PROTECTED)
+@Getter
+@Setter(AccessLevel.PROTECTED)
 @ToString
 @EqualsAndHashCode
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/FieldDefinition.java
+++ b/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/FieldDefinition.java
@@ -15,14 +15,6 @@
  */
 package com.github.dozermapper.core.builder.model.jaxb;
 
-import jakarta.xml.bind.annotation.XmlAccessType;
-import jakarta.xml.bind.annotation.XmlAccessorType;
-import jakarta.xml.bind.annotation.XmlAttribute;
-import jakarta.xml.bind.annotation.XmlElement;
-import jakarta.xml.bind.annotation.XmlRootElement;
-import jakarta.xml.bind.annotation.XmlTransient;
-import jakarta.xml.bind.annotation.XmlType;
-
 import com.github.dozermapper.core.MappingException;
 import com.github.dozermapper.core.classmap.ClassMap;
 import com.github.dozermapper.core.classmap.MappingDirection;
@@ -36,12 +28,15 @@ import com.github.dozermapper.core.fieldmap.GenericFieldMap;
 import com.github.dozermapper.core.fieldmap.HintContainer;
 import com.github.dozermapper.core.fieldmap.MapFieldMap;
 import com.github.dozermapper.core.propertydescriptor.PropertyDescriptorFactory;
-import lombok.AccessLevel;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlTransient;
+import jakarta.xml.bind.annotation.XmlType;
 import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.Setter;
 import lombok.ToString;
-
 import org.apache.commons.lang3.StringUtils;
 
 /**
@@ -75,8 +70,8 @@ import org.apache.commons.lang3.StringUtils;
  * custom-converter Indicates that a specific custom converter should be used for mapping this field. Typically
  * this will not be specified.
  */
-@Getter
-@Setter(AccessLevel.PROTECTED)
+//@Getter
+//@Setter(AccessLevel.PROTECTED)
 @ToString
 @EqualsAndHashCode
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/FieldDefinition.java
+++ b/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/FieldDefinition.java
@@ -15,6 +15,14 @@
  */
 package com.github.dozermapper.core.builder.model.jaxb;
 
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlTransient;
+import jakarta.xml.bind.annotation.XmlType;
+
 import com.github.dozermapper.core.MappingException;
 import com.github.dozermapper.core.classmap.ClassMap;
 import com.github.dozermapper.core.classmap.MappingDirection;
@@ -28,15 +36,12 @@ import com.github.dozermapper.core.fieldmap.GenericFieldMap;
 import com.github.dozermapper.core.fieldmap.HintContainer;
 import com.github.dozermapper.core.fieldmap.MapFieldMap;
 import com.github.dozermapper.core.propertydescriptor.PropertyDescriptorFactory;
-import jakarta.xml.bind.annotation.XmlAccessType;
-import jakarta.xml.bind.annotation.XmlAccessorType;
-import jakarta.xml.bind.annotation.XmlAttribute;
-import jakarta.xml.bind.annotation.XmlElement;
-import jakarta.xml.bind.annotation.XmlRootElement;
-import jakarta.xml.bind.annotation.XmlTransient;
-import jakarta.xml.bind.annotation.XmlType;
+import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
 import lombok.ToString;
+
 import org.apache.commons.lang3.StringUtils;
 
 /**
@@ -70,8 +75,8 @@ import org.apache.commons.lang3.StringUtils;
  * custom-converter Indicates that a specific custom converter should be used for mapping this field. Typically
  * this will not be specified.
  */
-//@Getter
-//@Setter(AccessLevel.PROTECTED)
+@Getter
+@Setter(AccessLevel.PROTECTED)
 @ToString
 @EqualsAndHashCode
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/FieldDefinition.java
+++ b/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/FieldDefinition.java
@@ -15,13 +15,13 @@
  */
 package com.github.dozermapper.core.builder.model.jaxb;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlTransient;
-import javax.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlTransient;
+import jakarta.xml.bind.annotation.XmlType;
 
 import com.github.dozermapper.core.MappingException;
 import com.github.dozermapper.core.classmap.ClassMap;
@@ -312,5 +312,125 @@ public class FieldDefinition {
         }
 
         return hintContainer;
+    }
+
+    public MappingDefinition getParentMappingDefinition() {
+        return parentMappingDefinition;
+    }
+
+    public FieldExcludeDefinition getParentFieldExclude() {
+        return parentFieldExclude;
+    }
+
+    public FieldDefinitionDefinition getA() {
+        return a;
+    }
+
+    protected void setA(FieldDefinitionDefinition a) {
+        this.a = a;
+    }
+
+    public FieldDefinitionDefinition getB() {
+        return b;
+    }
+
+    protected void setB(FieldDefinitionDefinition b) {
+        this.b = b;
+    }
+
+    public String getAHint() {
+        return aHint;
+    }
+
+    protected void setAHint(String aHint) {
+        this.aHint = aHint;
+    }
+
+    public String getBHint() {
+        return bHint;
+    }
+
+    protected void setBHint(String bHint) {
+        this.bHint = bHint;
+    }
+
+    public String getADeepIndexHint() {
+        return aDeepIndexHint;
+    }
+
+    protected void setADeepIndexHint(String aDeepIndexHint) {
+        this.aDeepIndexHint = aDeepIndexHint;
+    }
+
+    public String getBDeepIndexHint() {
+        return bDeepIndexHint;
+    }
+
+    protected void setBDeepIndexHint(String bDeepIndexHint) {
+        this.bDeepIndexHint = bDeepIndexHint;
+    }
+
+    public Relationship getRelationshipType() {
+        return relationshipType;
+    }
+
+    protected void setRelationshipType(Relationship relationshipType) {
+        this.relationshipType = relationshipType;
+    }
+
+    public Boolean getRemoveOrphans() {
+        return removeOrphans;
+    }
+
+    protected void setRemoveOrphans(Boolean removeOrphans) {
+        this.removeOrphans = removeOrphans;
+    }
+
+    public Type getType() {
+        return type;
+    }
+
+    protected void setType(Type type) {
+        this.type = type;
+    }
+
+    public String getMapId() {
+        return mapId;
+    }
+
+    protected void setMapId(String mapId) {
+        this.mapId = mapId;
+    }
+
+    public Boolean getCopyByReference() {
+        return copyByReference;
+    }
+
+    protected void setCopyByReference(Boolean copyByReference) {
+        this.copyByReference = copyByReference;
+    }
+
+    public String getCustomConverter() {
+        return customConverter;
+    }
+
+    protected void setCustomConverter(String customConverter) {
+        this.customConverter = customConverter;
+    }
+
+    public String getCustomConverterId() {
+        return customConverterId;
+    }
+
+    protected void setCustomConverterId(String customConverterId) {
+        this.customConverterId = customConverterId;
+    }
+
+    public String getCustomConverterParam() {
+        return customConverterParam;
+    }
+
+    protected void setCustomConverterParam(String customConverterParam) {
+        this.customConverterParam = customConverterParam;
     }
 }

--- a/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/FieldDefinition.java
+++ b/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/FieldDefinition.java
@@ -22,7 +22,6 @@ import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import jakarta.xml.bind.annotation.XmlTransient;
 import jakarta.xml.bind.annotation.XmlType;
-
 import com.github.dozermapper.core.MappingException;
 import com.github.dozermapper.core.classmap.ClassMap;
 import com.github.dozermapper.core.classmap.MappingDirection;
@@ -36,12 +35,8 @@ import com.github.dozermapper.core.fieldmap.GenericFieldMap;
 import com.github.dozermapper.core.fieldmap.HintContainer;
 import com.github.dozermapper.core.fieldmap.MapFieldMap;
 import com.github.dozermapper.core.propertydescriptor.PropertyDescriptorFactory;
-import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.Setter;
 import lombok.ToString;
-
 import org.apache.commons.lang3.StringUtils;
 
 /**
@@ -75,8 +70,6 @@ import org.apache.commons.lang3.StringUtils;
  * custom-converter Indicates that a specific custom converter should be used for mapping this field. Typically
  * this will not be specified.
  */
-@Getter
-@Setter(AccessLevel.PROTECTED)
 @ToString
 @EqualsAndHashCode
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/FieldDefinitionDefinition.java
+++ b/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/FieldDefinitionDefinition.java
@@ -15,17 +15,22 @@
  */
 package com.github.dozermapper.core.builder.model.jaxb;
 
-import com.github.dozermapper.core.MappingException;
-import com.github.dozermapper.core.fieldmap.DozerField;
-import com.github.dozermapper.core.util.MappingUtils;
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlAttribute;
 import jakarta.xml.bind.annotation.XmlTransient;
 import jakarta.xml.bind.annotation.XmlType;
 import jakarta.xml.bind.annotation.XmlValue;
+
+import com.github.dozermapper.core.MappingException;
+import com.github.dozermapper.core.fieldmap.DozerField;
+import com.github.dozermapper.core.util.MappingUtils;
+import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
 import lombok.ToString;
+
 import org.apache.commons.lang3.StringUtils;
 
 /**
@@ -49,8 +54,8 @@ import org.apache.commons.lang3.StringUtils;
  * getter/setter methods will NOT be invoked. You would want to set this to "true" if the field is lacking a getter or setter method
  * skip-constructor Indicates whether Dozer bypasses constructors and instantiates an object with a no-arg constructor.
  */
-//@Getter
-//@Setter(AccessLevel.PUBLIC)
+@Getter
+@Setter(AccessLevel.PUBLIC)
 @ToString
 @EqualsAndHashCode
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/FieldDefinitionDefinition.java
+++ b/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/FieldDefinitionDefinition.java
@@ -21,16 +21,11 @@ import jakarta.xml.bind.annotation.XmlAttribute;
 import jakarta.xml.bind.annotation.XmlTransient;
 import jakarta.xml.bind.annotation.XmlType;
 import jakarta.xml.bind.annotation.XmlValue;
-
 import com.github.dozermapper.core.MappingException;
 import com.github.dozermapper.core.fieldmap.DozerField;
 import com.github.dozermapper.core.util.MappingUtils;
-import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.Setter;
 import lombok.ToString;
-
 import org.apache.commons.lang3.StringUtils;
 
 /**
@@ -54,8 +49,6 @@ import org.apache.commons.lang3.StringUtils;
  * getter/setter methods will NOT be invoked. You would want to set this to "true" if the field is lacking a getter or setter method
  * skip-constructor Indicates whether Dozer bypasses constructors and instantiates an object with a no-arg constructor.
  */
-@Getter
-@Setter(AccessLevel.PUBLIC)
 @ToString
 @EqualsAndHashCode
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/FieldDefinitionDefinition.java
+++ b/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/FieldDefinitionDefinition.java
@@ -15,12 +15,12 @@
  */
 package com.github.dozermapper.core.builder.model.jaxb;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlTransient;
-import javax.xml.bind.annotation.XmlType;
-import javax.xml.bind.annotation.XmlValue;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlTransient;
+import jakarta.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.XmlValue;
 
 import com.github.dozermapper.core.MappingException;
 import com.github.dozermapper.core.fieldmap.DozerField;
@@ -55,7 +55,7 @@ import org.apache.commons.lang3.StringUtils;
  * skip-constructor Indicates whether Dozer bypasses constructors and instantiates an object with a no-arg constructor.
  */
 @Getter
-@Setter(AccessLevel.PROTECTED)
+@Setter(AccessLevel.PUBLIC)
 @ToString
 @EqualsAndHashCode
 @XmlAccessorType(XmlAccessType.FIELD)
@@ -235,5 +235,93 @@ public class FieldDefinitionDefinition {
 
     private int getIndexOfIndexedField(String fieldName) {
         return Integer.parseInt(fieldName.replaceAll(".*\\[", "").replaceAll("\\]", ""));
+    }
+
+    public FieldExcludeDefinition getFieldExcludeParent() {
+        return fieldExcludeParent;
+    }
+
+    public FieldDefinition getFieldParent() {
+        return fieldParent;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    protected void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDateFormat() {
+        return dateFormat;
+    }
+
+    protected void setDateFormat(String dateFormat) {
+        this.dateFormat = dateFormat;
+    }
+
+    public FieldType getType() {
+        return type;
+    }
+
+    protected void setType(FieldType type) {
+        this.type = type;
+    }
+
+    public String getSetMethod() {
+        return setMethod;
+    }
+
+    protected void setSetMethod(String setMethod) {
+        this.setMethod = setMethod;
+    }
+
+    public String getGetMethod() {
+        return getMethod;
+    }
+
+    protected void setGetMethod(String getMethod) {
+        this.getMethod = getMethod;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    protected void setKey(String key) {
+        this.key = key;
+    }
+
+    public String getMapSetMethod() {
+        return mapSetMethod;
+    }
+
+    protected void setMapSetMethod(String mapSetMethod) {
+        this.mapSetMethod = mapSetMethod;
+    }
+
+    public String getMapGetMethod() {
+        return mapGetMethod;
+    }
+
+    protected void setMapGetMethod(String mapGetMethod) {
+        this.mapGetMethod = mapGetMethod;
+    }
+
+    public Boolean getIsAccessible() {
+        return isAccessible;
+    }
+
+    protected void setIsAccessible(Boolean accessible) {
+        isAccessible = accessible;
+    }
+
+    public String getCreateMethod() {
+        return createMethod;
+    }
+
+    protected void setCreateMethod(String createMethod) {
+        this.createMethod = createMethod;
     }
 }

--- a/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/FieldDefinitionDefinition.java
+++ b/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/FieldDefinitionDefinition.java
@@ -15,22 +15,17 @@
  */
 package com.github.dozermapper.core.builder.model.jaxb;
 
+import com.github.dozermapper.core.MappingException;
+import com.github.dozermapper.core.fieldmap.DozerField;
+import com.github.dozermapper.core.util.MappingUtils;
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlAttribute;
 import jakarta.xml.bind.annotation.XmlTransient;
 import jakarta.xml.bind.annotation.XmlType;
 import jakarta.xml.bind.annotation.XmlValue;
-
-import com.github.dozermapper.core.MappingException;
-import com.github.dozermapper.core.fieldmap.DozerField;
-import com.github.dozermapper.core.util.MappingUtils;
-import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.Setter;
 import lombok.ToString;
-
 import org.apache.commons.lang3.StringUtils;
 
 /**
@@ -54,8 +49,8 @@ import org.apache.commons.lang3.StringUtils;
  * getter/setter methods will NOT be invoked. You would want to set this to "true" if the field is lacking a getter or setter method
  * skip-constructor Indicates whether Dozer bypasses constructors and instantiates an object with a no-arg constructor.
  */
-@Getter
-@Setter(AccessLevel.PUBLIC)
+//@Getter
+//@Setter(AccessLevel.PUBLIC)
 @ToString
 @EqualsAndHashCode
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/FieldExcludeDefinition.java
+++ b/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/FieldExcludeDefinition.java
@@ -15,13 +15,13 @@
  */
 package com.github.dozermapper.core.builder.model.jaxb;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlTransient;
-import javax.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlTransient;
+import jakarta.xml.bind.annotation.XmlType;
 
 import com.github.dozermapper.core.classmap.ClassMap;
 import com.github.dozermapper.core.classmap.MappingDirection;
@@ -107,5 +107,33 @@ public class FieldExcludeDefinition {
         }
 
         return fieldMap;
+    }
+
+    public MappingDefinition getParent() {
+        return parent;
+    }
+
+    public FieldDefinitionDefinition getA() {
+        return a;
+    }
+
+    protected void setA(FieldDefinitionDefinition a) {
+        this.a = a;
+    }
+
+    public FieldDefinitionDefinition getB() {
+        return b;
+    }
+
+    protected void setB(FieldDefinitionDefinition b) {
+        this.b = b;
+    }
+
+    public Type getType() {
+        return type;
+    }
+
+    protected void setType(Type type) {
+        this.type = type;
     }
 }

--- a/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/FieldExcludeDefinition.java
+++ b/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/FieldExcludeDefinition.java
@@ -22,7 +22,6 @@ import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import jakarta.xml.bind.annotation.XmlTransient;
 import jakarta.xml.bind.annotation.XmlType;
-
 import com.github.dozermapper.core.classmap.ClassMap;
 import com.github.dozermapper.core.classmap.MappingDirection;
 import com.github.dozermapper.core.config.BeanContainer;
@@ -31,17 +30,12 @@ import com.github.dozermapper.core.fieldmap.DozerField;
 import com.github.dozermapper.core.fieldmap.ExcludeFieldMap;
 import com.github.dozermapper.core.fieldmap.FieldMap;
 import com.github.dozermapper.core.propertydescriptor.PropertyDescriptorFactory;
-import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.Setter;
 import lombok.ToString;
 
 /**
  * Exclude a particular field from being mapped
  */
-@Getter
-@Setter(AccessLevel.PROTECTED)
 @ToString
 @EqualsAndHashCode
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/FieldExcludeDefinition.java
+++ b/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/FieldExcludeDefinition.java
@@ -15,14 +15,6 @@
  */
 package com.github.dozermapper.core.builder.model.jaxb;
 
-import jakarta.xml.bind.annotation.XmlAccessType;
-import jakarta.xml.bind.annotation.XmlAccessorType;
-import jakarta.xml.bind.annotation.XmlAttribute;
-import jakarta.xml.bind.annotation.XmlElement;
-import jakarta.xml.bind.annotation.XmlRootElement;
-import jakarta.xml.bind.annotation.XmlTransient;
-import jakarta.xml.bind.annotation.XmlType;
-
 import com.github.dozermapper.core.classmap.ClassMap;
 import com.github.dozermapper.core.classmap.MappingDirection;
 import com.github.dozermapper.core.config.BeanContainer;
@@ -31,17 +23,21 @@ import com.github.dozermapper.core.fieldmap.DozerField;
 import com.github.dozermapper.core.fieldmap.ExcludeFieldMap;
 import com.github.dozermapper.core.fieldmap.FieldMap;
 import com.github.dozermapper.core.propertydescriptor.PropertyDescriptorFactory;
-import lombok.AccessLevel;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlTransient;
+import jakarta.xml.bind.annotation.XmlType;
 import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.Setter;
 import lombok.ToString;
 
 /**
  * Exclude a particular field from being mapped
  */
-@Getter
-@Setter(AccessLevel.PROTECTED)
+//@Getter
+//@Setter(AccessLevel.PROTECTED)
 @ToString
 @EqualsAndHashCode
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/FieldExcludeDefinition.java
+++ b/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/FieldExcludeDefinition.java
@@ -15,6 +15,14 @@
  */
 package com.github.dozermapper.core.builder.model.jaxb;
 
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlTransient;
+import jakarta.xml.bind.annotation.XmlType;
+
 import com.github.dozermapper.core.classmap.ClassMap;
 import com.github.dozermapper.core.classmap.MappingDirection;
 import com.github.dozermapper.core.config.BeanContainer;
@@ -23,21 +31,17 @@ import com.github.dozermapper.core.fieldmap.DozerField;
 import com.github.dozermapper.core.fieldmap.ExcludeFieldMap;
 import com.github.dozermapper.core.fieldmap.FieldMap;
 import com.github.dozermapper.core.propertydescriptor.PropertyDescriptorFactory;
-import jakarta.xml.bind.annotation.XmlAccessType;
-import jakarta.xml.bind.annotation.XmlAccessorType;
-import jakarta.xml.bind.annotation.XmlAttribute;
-import jakarta.xml.bind.annotation.XmlElement;
-import jakarta.xml.bind.annotation.XmlRootElement;
-import jakarta.xml.bind.annotation.XmlTransient;
-import jakarta.xml.bind.annotation.XmlType;
+import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
 import lombok.ToString;
 
 /**
  * Exclude a particular field from being mapped
  */
-//@Getter
-//@Setter(AccessLevel.PROTECTED)
+@Getter
+@Setter(AccessLevel.PROTECTED)
 @ToString
 @EqualsAndHashCode
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/FieldType.java
+++ b/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/FieldType.java
@@ -15,9 +15,9 @@
  */
 package com.github.dozermapper.core.builder.model.jaxb;
 
-import javax.xml.bind.annotation.XmlEnum;
-import javax.xml.bind.annotation.XmlEnumValue;
-import javax.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.XmlEnum;
+import jakarta.xml.bind.annotation.XmlEnumValue;
+import jakarta.xml.bind.annotation.XmlType;
 
 import lombok.ToString;
 

--- a/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/MappingDefinition.java
+++ b/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/MappingDefinition.java
@@ -18,14 +18,14 @@ package com.github.dozermapper.core.builder.model.jaxb;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlElements;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlTransient;
-import javax.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlElements;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlTransient;
+import jakarta.xml.bind.annotation.XmlType;
 
 import com.github.dozermapper.core.classmap.ClassMap;
 import com.github.dozermapper.core.classmap.Configuration;
@@ -329,5 +329,137 @@ public class MappingDefinition {
         }
 
         return answer;
+    }
+
+    public MappingsDefinition getParent() {
+        return parent;
+    }
+
+    public ClassDefinition getClassA() {
+        return classA;
+    }
+
+    protected void setClassA(ClassDefinition classA) {
+        this.classA = classA;
+    }
+
+    public ClassDefinition getClassB() {
+        return classB;
+    }
+
+    protected void setClassB(ClassDefinition classB) {
+        this.classB = classB;
+    }
+
+    public List<Object> getFieldOrFieldExclude() {
+        return fieldOrFieldExclude;
+    }
+
+    protected void setFieldOrFieldExclude(List<Object> fieldOrFieldExclude) {
+        this.fieldOrFieldExclude = fieldOrFieldExclude;
+    }
+
+    public List<FieldDefinition> getFields() {
+        return fields;
+    }
+
+    protected void setFields(List<FieldDefinition> fields) {
+        this.fields = fields;
+    }
+
+    public List<FieldExcludeDefinition> getFieldExcludes() {
+        return fieldExcludes;
+    }
+
+    protected void setFieldExcludes(List<FieldExcludeDefinition> fieldExcludes) {
+        this.fieldExcludes = fieldExcludes;
+    }
+
+    public String getDateFormat() {
+        return dateFormat;
+    }
+
+    protected void setDateFormat(String dateFormat) {
+        this.dateFormat = dateFormat;
+    }
+
+    public Boolean getStopOnErrors() {
+        return stopOnErrors;
+    }
+
+    protected void setStopOnErrors(Boolean stopOnErrors) {
+        this.stopOnErrors = stopOnErrors;
+    }
+
+    public Boolean getWildcard() {
+        return wildcard;
+    }
+
+    protected void setWildcard(Boolean wildcard) {
+        this.wildcard = wildcard;
+    }
+
+    public Boolean getWildcardCaseInsensitive() {
+        return wildcardCaseInsensitive;
+    }
+
+    protected void setWildcardCaseInsensitive(Boolean wildcardCaseInsensitive) {
+        this.wildcardCaseInsensitive = wildcardCaseInsensitive;
+    }
+
+    public Boolean getTrimStrings() {
+        return trimStrings;
+    }
+
+    protected void setTrimStrings(Boolean trimStrings) {
+        this.trimStrings = trimStrings;
+    }
+
+    public Boolean getMapNull() {
+        return mapNull;
+    }
+
+    protected void setMapNull(Boolean mapNull) {
+        this.mapNull = mapNull;
+    }
+
+    public Boolean getMapEmptyString() {
+        return mapEmptyString;
+    }
+
+    protected void setMapEmptyString(Boolean mapEmptyString) {
+        this.mapEmptyString = mapEmptyString;
+    }
+
+    public String getBeanFactory() {
+        return beanFactory;
+    }
+
+    protected void setBeanFactory(String beanFactory) {
+        this.beanFactory = beanFactory;
+    }
+
+    public Type getType() {
+        return type;
+    }
+
+    protected void setType(Type type) {
+        this.type = type;
+    }
+
+    public Relationship getRelationshipType() {
+        return relationshipType;
+    }
+
+    protected void setRelationshipType(Relationship relationshipType) {
+        this.relationshipType = relationshipType;
+    }
+
+    public String getMapId() {
+        return mapId;
+    }
+
+    protected void setMapId(String mapId) {
+        this.mapId = mapId;
     }
 }

--- a/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/MappingDefinition.java
+++ b/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/MappingDefinition.java
@@ -17,7 +17,6 @@ package com.github.dozermapper.core.builder.model.jaxb;
 
 import java.util.ArrayList;
 import java.util.List;
-
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlAttribute;
@@ -26,7 +25,6 @@ import jakarta.xml.bind.annotation.XmlElements;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import jakarta.xml.bind.annotation.XmlTransient;
 import jakarta.xml.bind.annotation.XmlType;
-
 import com.github.dozermapper.core.classmap.ClassMap;
 import com.github.dozermapper.core.classmap.Configuration;
 import com.github.dozermapper.core.classmap.MappingDirection;
@@ -35,10 +33,7 @@ import com.github.dozermapper.core.config.BeanContainer;
 import com.github.dozermapper.core.factory.DestBeanCreator;
 import com.github.dozermapper.core.fieldmap.FieldMap;
 import com.github.dozermapper.core.propertydescriptor.PropertyDescriptorFactory;
-import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.Setter;
 import lombok.ToString;
 
 /**
@@ -84,8 +79,6 @@ import lombok.ToString;
  * <p>
  * non-cumulative indicates the element will be added or an existing entry will be updated.
  */
-@Getter
-@Setter(AccessLevel.PROTECTED)
 @ToString
 @EqualsAndHashCode
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/MappingDefinition.java
+++ b/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/MappingDefinition.java
@@ -15,18 +15,6 @@
  */
 package com.github.dozermapper.core.builder.model.jaxb;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import jakarta.xml.bind.annotation.XmlAccessType;
-import jakarta.xml.bind.annotation.XmlAccessorType;
-import jakarta.xml.bind.annotation.XmlAttribute;
-import jakarta.xml.bind.annotation.XmlElement;
-import jakarta.xml.bind.annotation.XmlElements;
-import jakarta.xml.bind.annotation.XmlRootElement;
-import jakarta.xml.bind.annotation.XmlTransient;
-import jakarta.xml.bind.annotation.XmlType;
-
 import com.github.dozermapper.core.classmap.ClassMap;
 import com.github.dozermapper.core.classmap.Configuration;
 import com.github.dozermapper.core.classmap.MappingDirection;
@@ -35,10 +23,17 @@ import com.github.dozermapper.core.config.BeanContainer;
 import com.github.dozermapper.core.factory.DestBeanCreator;
 import com.github.dozermapper.core.fieldmap.FieldMap;
 import com.github.dozermapper.core.propertydescriptor.PropertyDescriptorFactory;
-import lombok.AccessLevel;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlElements;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlTransient;
+import jakarta.xml.bind.annotation.XmlType;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.Setter;
 import lombok.ToString;
 
 /**
@@ -84,8 +79,8 @@ import lombok.ToString;
  * <p>
  * non-cumulative indicates the element will be added or an existing entry will be updated.
  */
-@Getter
-@Setter(AccessLevel.PROTECTED)
+//@Getter
+//@Setter(AccessLevel.PROTECTED)
 @ToString
 @EqualsAndHashCode
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/MappingDefinition.java
+++ b/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/MappingDefinition.java
@@ -15,14 +15,9 @@
  */
 package com.github.dozermapper.core.builder.model.jaxb;
 
-import com.github.dozermapper.core.classmap.ClassMap;
-import com.github.dozermapper.core.classmap.Configuration;
-import com.github.dozermapper.core.classmap.MappingDirection;
-import com.github.dozermapper.core.classmap.RelationshipType;
-import com.github.dozermapper.core.config.BeanContainer;
-import com.github.dozermapper.core.factory.DestBeanCreator;
-import com.github.dozermapper.core.fieldmap.FieldMap;
-import com.github.dozermapper.core.propertydescriptor.PropertyDescriptorFactory;
+import java.util.ArrayList;
+import java.util.List;
+
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlAttribute;
@@ -31,9 +26,19 @@ import jakarta.xml.bind.annotation.XmlElements;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import jakarta.xml.bind.annotation.XmlTransient;
 import jakarta.xml.bind.annotation.XmlType;
-import java.util.ArrayList;
-import java.util.List;
+
+import com.github.dozermapper.core.classmap.ClassMap;
+import com.github.dozermapper.core.classmap.Configuration;
+import com.github.dozermapper.core.classmap.MappingDirection;
+import com.github.dozermapper.core.classmap.RelationshipType;
+import com.github.dozermapper.core.config.BeanContainer;
+import com.github.dozermapper.core.factory.DestBeanCreator;
+import com.github.dozermapper.core.fieldmap.FieldMap;
+import com.github.dozermapper.core.propertydescriptor.PropertyDescriptorFactory;
+import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
 import lombok.ToString;
 
 /**
@@ -79,8 +84,8 @@ import lombok.ToString;
  * <p>
  * non-cumulative indicates the element will be added or an existing entry will be updated.
  */
-//@Getter
-//@Setter(AccessLevel.PROTECTED)
+@Getter
+@Setter(AccessLevel.PROTECTED)
 @ToString
 @EqualsAndHashCode
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/MappingsDefinition.java
+++ b/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/MappingsDefinition.java
@@ -18,12 +18,12 @@ package com.github.dozermapper.core.builder.model.jaxb;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlTransient;
-import javax.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlTransient;
+import jakarta.xml.bind.annotation.XmlType;
 
 import com.github.dozermapper.core.classmap.ClassMap;
 import com.github.dozermapper.core.classmap.Configuration;
@@ -90,5 +90,29 @@ public class MappingsDefinition {
         }
 
         return answer;
+    }
+
+    public String getSchemaLocation() {
+        return schemaLocation;
+    }
+
+    protected void setSchemaLocation(String schemaLocation) {
+        this.schemaLocation = schemaLocation;
+    }
+
+    public ConfigurationDefinition getConfiguration() {
+        return configuration;
+    }
+
+    protected void setConfiguration(ConfigurationDefinition configuration) {
+        this.configuration = configuration;
+    }
+
+    public List<MappingDefinition> getMapping() {
+        return mapping;
+    }
+
+    protected void setMapping(List<MappingDefinition> mapping) {
+        this.mapping = mapping;
     }
 }

--- a/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/MappingsDefinition.java
+++ b/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/MappingsDefinition.java
@@ -15,28 +15,33 @@
  */
 package com.github.dozermapper.core.builder.model.jaxb;
 
-import com.github.dozermapper.core.classmap.ClassMap;
-import com.github.dozermapper.core.classmap.Configuration;
-import com.github.dozermapper.core.config.BeanContainer;
-import com.github.dozermapper.core.factory.DestBeanCreator;
-import com.github.dozermapper.core.propertydescriptor.PropertyDescriptorFactory;
+import java.util.ArrayList;
+import java.util.List;
+
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import jakarta.xml.bind.annotation.XmlTransient;
 import jakarta.xml.bind.annotation.XmlType;
-import java.util.ArrayList;
-import java.util.List;
+
+import com.github.dozermapper.core.classmap.ClassMap;
+import com.github.dozermapper.core.classmap.Configuration;
+import com.github.dozermapper.core.config.BeanContainer;
+import com.github.dozermapper.core.factory.DestBeanCreator;
+import com.github.dozermapper.core.propertydescriptor.PropertyDescriptorFactory;
+import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import lombok.ToString;
 
 /**
  * The document root.
  */
-//@Getter
-//@Setter(AccessLevel.PROTECTED)
+@Getter
+@Setter(AccessLevel.PROTECTED)
 @ToString
 @EqualsAndHashCode
 @NoArgsConstructor

--- a/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/MappingsDefinition.java
+++ b/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/MappingsDefinition.java
@@ -15,33 +15,28 @@
  */
 package com.github.dozermapper.core.builder.model.jaxb;
 
-import java.util.ArrayList;
-import java.util.List;
-
+import com.github.dozermapper.core.classmap.ClassMap;
+import com.github.dozermapper.core.classmap.Configuration;
+import com.github.dozermapper.core.config.BeanContainer;
+import com.github.dozermapper.core.factory.DestBeanCreator;
+import com.github.dozermapper.core.propertydescriptor.PropertyDescriptorFactory;
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import jakarta.xml.bind.annotation.XmlTransient;
 import jakarta.xml.bind.annotation.XmlType;
-
-import com.github.dozermapper.core.classmap.ClassMap;
-import com.github.dozermapper.core.classmap.Configuration;
-import com.github.dozermapper.core.config.BeanContainer;
-import com.github.dozermapper.core.factory.DestBeanCreator;
-import com.github.dozermapper.core.propertydescriptor.PropertyDescriptorFactory;
-import lombok.AccessLevel;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.EqualsAndHashCode;
-import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 import lombok.ToString;
 
 /**
  * The document root.
  */
-@Getter
-@Setter(AccessLevel.PROTECTED)
+//@Getter
+//@Setter(AccessLevel.PROTECTED)
 @ToString
 @EqualsAndHashCode
 @NoArgsConstructor

--- a/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/MappingsDefinition.java
+++ b/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/MappingsDefinition.java
@@ -17,31 +17,24 @@ package com.github.dozermapper.core.builder.model.jaxb;
 
 import java.util.ArrayList;
 import java.util.List;
-
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import jakarta.xml.bind.annotation.XmlTransient;
 import jakarta.xml.bind.annotation.XmlType;
-
 import com.github.dozermapper.core.classmap.ClassMap;
 import com.github.dozermapper.core.classmap.Configuration;
 import com.github.dozermapper.core.config.BeanContainer;
 import com.github.dozermapper.core.factory.DestBeanCreator;
 import com.github.dozermapper.core.propertydescriptor.PropertyDescriptorFactory;
-import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
-import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 import lombok.ToString;
 
 /**
  * The document root.
  */
-@Getter
-@Setter(AccessLevel.PROTECTED)
 @ToString
 @EqualsAndHashCode
 @NoArgsConstructor

--- a/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/Relationship.java
+++ b/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/Relationship.java
@@ -15,9 +15,9 @@
  */
 package com.github.dozermapper.core.builder.model.jaxb;
 
-import javax.xml.bind.annotation.XmlEnum;
-import javax.xml.bind.annotation.XmlEnumValue;
-import javax.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.XmlEnum;
+import jakarta.xml.bind.annotation.XmlEnumValue;
+import jakarta.xml.bind.annotation.XmlType;
 
 import lombok.ToString;
 

--- a/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/Type.java
+++ b/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/Type.java
@@ -15,9 +15,9 @@
  */
 package com.github.dozermapper.core.builder.model.jaxb;
 
-import javax.xml.bind.annotation.XmlEnum;
-import javax.xml.bind.annotation.XmlEnumValue;
-import javax.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.XmlEnum;
+import jakarta.xml.bind.annotation.XmlEnumValue;
+import jakarta.xml.bind.annotation.XmlType;
 
 import lombok.ToString;
 

--- a/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/VariableDefinition.java
+++ b/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/VariableDefinition.java
@@ -15,12 +15,12 @@
  */
 package com.github.dozermapper.core.builder.model.jaxb;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlTransient;
-import javax.xml.bind.annotation.XmlType;
-import javax.xml.bind.annotation.XmlValue;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlTransient;
+import jakarta.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.XmlValue;
 
 import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
@@ -73,5 +73,25 @@ public class VariableDefinition {
 
     public void build() {
         //NOOP
+    }
+
+    public VariablesDefinition getParent() {
+        return parent;
+    }
+
+    public String getClazz() {
+        return clazz;
+    }
+
+    protected void setClazz(String clazz) {
+        this.clazz = clazz;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    protected void setName(String name) {
+        this.name = name;
     }
 }

--- a/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/VariableDefinition.java
+++ b/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/VariableDefinition.java
@@ -21,11 +21,15 @@ import jakarta.xml.bind.annotation.XmlAttribute;
 import jakarta.xml.bind.annotation.XmlTransient;
 import jakarta.xml.bind.annotation.XmlType;
 import jakarta.xml.bind.annotation.XmlValue;
+
+import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
 import lombok.ToString;
 
-//@Getter
-//@Setter(AccessLevel.PROTECTED)
+@Getter
+@Setter(AccessLevel.PROTECTED)
 @ToString
 @EqualsAndHashCode
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/VariableDefinition.java
+++ b/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/VariableDefinition.java
@@ -21,15 +21,11 @@ import jakarta.xml.bind.annotation.XmlAttribute;
 import jakarta.xml.bind.annotation.XmlTransient;
 import jakarta.xml.bind.annotation.XmlType;
 import jakarta.xml.bind.annotation.XmlValue;
-
-import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.Setter;
 import lombok.ToString;
 
-@Getter
-@Setter(AccessLevel.PROTECTED)
+//@Getter
+//@Setter(AccessLevel.PROTECTED)
 @ToString
 @EqualsAndHashCode
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/VariableDefinition.java
+++ b/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/VariableDefinition.java
@@ -21,15 +21,9 @@ import jakarta.xml.bind.annotation.XmlAttribute;
 import jakarta.xml.bind.annotation.XmlTransient;
 import jakarta.xml.bind.annotation.XmlType;
 import jakarta.xml.bind.annotation.XmlValue;
-
-import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.Setter;
 import lombok.ToString;
 
-@Getter
-@Setter(AccessLevel.PROTECTED)
 @ToString
 @EqualsAndHashCode
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/VariablesDefinition.java
+++ b/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/VariablesDefinition.java
@@ -15,19 +15,24 @@
  */
 package com.github.dozermapper.core.builder.model.jaxb;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import jakarta.xml.bind.annotation.XmlTransient;
 import jakarta.xml.bind.annotation.XmlType;
-import java.util.ArrayList;
-import java.util.List;
+
+import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
 import lombok.ToString;
 
-//@Getter
-//@Setter(AccessLevel.PROTECTED)
+@Getter
+@Setter(AccessLevel.PROTECTED)
 @ToString
 @EqualsAndHashCode
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/VariablesDefinition.java
+++ b/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/VariablesDefinition.java
@@ -15,24 +15,19 @@
  */
 package com.github.dozermapper.core.builder.model.jaxb;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import jakarta.xml.bind.annotation.XmlTransient;
 import jakarta.xml.bind.annotation.XmlType;
-
-import lombok.AccessLevel;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.Setter;
 import lombok.ToString;
 
-@Getter
-@Setter(AccessLevel.PROTECTED)
+//@Getter
+//@Setter(AccessLevel.PROTECTED)
 @ToString
 @EqualsAndHashCode
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/VariablesDefinition.java
+++ b/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/VariablesDefinition.java
@@ -17,22 +17,15 @@ package com.github.dozermapper.core.builder.model.jaxb;
 
 import java.util.ArrayList;
 import java.util.List;
-
 import jakarta.xml.bind.annotation.XmlAccessType;
 import jakarta.xml.bind.annotation.XmlAccessorType;
 import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlRootElement;
 import jakarta.xml.bind.annotation.XmlTransient;
 import jakarta.xml.bind.annotation.XmlType;
-
-import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.Setter;
 import lombok.ToString;
 
-@Getter
-@Setter(AccessLevel.PROTECTED)
 @ToString
 @EqualsAndHashCode
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/VariablesDefinition.java
+++ b/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/VariablesDefinition.java
@@ -18,12 +18,12 @@ package com.github.dozermapper.core.builder.model.jaxb;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlTransient;
-import javax.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlTransient;
+import jakarta.xml.bind.annotation.XmlType;
 
 import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
@@ -77,5 +77,17 @@ public class VariablesDefinition {
                 current.build();
             }
         }
+    }
+
+    public ConfigurationDefinition getParent() {
+        return parent;
+    }
+
+    public List<VariableDefinition> getVariables() {
+        return variables;
+    }
+
+    protected void setVariables(List<VariableDefinition> variables) {
+        this.variables = variables;
     }
 }

--- a/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/package-info.java
+++ b/core/src/main/java/com/github/dozermapper/core/builder/model/jaxb/package-info.java
@@ -16,5 +16,5 @@
 /**
  * JAXB model that describes the mapping definitions
  */
-@javax.xml.bind.annotation.XmlSchema(namespace = "http://dozermapper.github.io/schema/bean-mapping", elementFormDefault = javax.xml.bind.annotation.XmlNsForm.QUALIFIED)
+@jakarta.xml.bind.annotation.XmlSchema(namespace = "http://dozermapper.github.io/schema/bean-mapping", elementFormDefault = jakarta.xml.bind.annotation.XmlNsForm.QUALIFIED)
 package com.github.dozermapper.core.builder.model.jaxb;

--- a/core/src/main/java/com/github/dozermapper/core/builder/xml/DefaultJAXBModelParser.java
+++ b/core/src/main/java/com/github/dozermapper/core/builder/xml/DefaultJAXBModelParser.java
@@ -25,9 +25,10 @@ import jakarta.xml.bind.Unmarshaller;
 
 import javax.xml.XMLConstants;
 import javax.xml.transform.stream.StreamSource;
-import javax.xml.validation.SchemaFactory;
 import javax.xml.validation.Schema;
+import javax.xml.validation.SchemaFactory;
 import javax.xml.validation.Validator;
+
 import org.w3c.dom.ls.LSResourceResolver;
 import org.xml.sax.SAXException;
 

--- a/core/src/main/java/com/github/dozermapper/core/builder/xml/DefaultJAXBModelParser.java
+++ b/core/src/main/java/com/github/dozermapper/core/builder/xml/DefaultJAXBModelParser.java
@@ -18,16 +18,16 @@ package com.github.dozermapper.core.builder.xml;
 import java.io.IOException;
 import java.io.StringReader;
 
-import javax.xml.XMLConstants;
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBElement;
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.Unmarshaller;
-import javax.xml.transform.stream.StreamSource;
-import javax.xml.validation.Schema;
-import javax.xml.validation.SchemaFactory;
-import javax.xml.validation.Validator;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBElement;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Unmarshaller;
 
+import javax.xml.XMLConstants;
+import javax.xml.transform.stream.StreamSource;
+import javax.xml.validation.SchemaFactory;
+import javax.xml.validation.Schema;
+import javax.xml.validation.Validator;
 import org.w3c.dom.ls.LSResourceResolver;
 import org.xml.sax.SAXException;
 

--- a/core/src/main/java/com/github/dozermapper/core/converters/CalendarConverter.java
+++ b/core/src/main/java/com/github/dozermapper/core/converters/CalendarConverter.java
@@ -20,9 +20,7 @@ import java.text.ParseException;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
-
 import javax.xml.datatype.XMLGregorianCalendar;
-
 import org.apache.commons.beanutils.Converter;
 
 /**

--- a/core/src/main/java/com/github/dozermapper/core/converters/PrimitiveOrWrapperConverter.java
+++ b/core/src/main/java/com/github/dozermapper/core/converters/PrimitiveOrWrapperConverter.java
@@ -28,7 +28,7 @@ import java.util.Calendar;
 import java.util.HashMap;
 import java.util.Map;
 
-import javax.xml.bind.JAXBElement;
+import jakarta.xml.bind.JAXBElement;
 import javax.xml.datatype.XMLGregorianCalendar;
 
 import com.github.dozermapper.core.config.BeanContainer;

--- a/core/src/main/java/com/github/dozermapper/core/el/DefaultELEngine.java
+++ b/core/src/main/java/com/github/dozermapper/core/el/DefaultELEngine.java
@@ -17,18 +17,18 @@ package com.github.dozermapper.core.el;
 
 import java.lang.reflect.Method;
 
-import javax.el.ArrayELResolver;
-import javax.el.BeanELResolver;
-import javax.el.CompositeELResolver;
-import javax.el.ELContext;
-import javax.el.ELResolver;
-import javax.el.ExpressionFactory;
-import javax.el.FunctionMapper;
-import javax.el.ListELResolver;
-import javax.el.MapELResolver;
-import javax.el.ResourceBundleELResolver;
-import javax.el.ValueExpression;
-import javax.el.VariableMapper;
+import jakarta.el.ArrayELResolver;
+import jakarta.el.BeanELResolver;
+import jakarta.el.CompositeELResolver;
+import jakarta.el.ELContext;
+import jakarta.el.ELResolver;
+import jakarta.el.ExpressionFactory;
+import jakarta.el.FunctionMapper;
+import jakarta.el.ListELResolver;
+import jakarta.el.MapELResolver;
+import jakarta.el.ResourceBundleELResolver;
+import jakarta.el.ValueExpression;
+import jakarta.el.VariableMapper;
 
 import com.github.dozermapper.core.el.contexts.SimpleELContext;
 

--- a/core/src/main/java/com/github/dozermapper/core/el/ELEngine.java
+++ b/core/src/main/java/com/github/dozermapper/core/el/ELEngine.java
@@ -18,7 +18,7 @@ package com.github.dozermapper.core.el;
 import java.lang.reflect.Method;
 
 /**
- * javax.el engine to resolve variables and functions
+ * jakarta.el engine to resolve variables and functions
  * See: <a href="https://dozermapper.github.io/gitbook/documentation/expressionlanguage.html">expression language</a>
  */
 public interface ELEngine {

--- a/core/src/main/java/com/github/dozermapper/core/el/ELExpressionFactory.java
+++ b/core/src/main/java/com/github/dozermapper/core/el/ELExpressionFactory.java
@@ -36,28 +36,28 @@ public final class ELExpressionFactory {
     }
 
     /**
-     * Checks whether javax.el is on the classpath and a {@link ExpressionFactory} can be constructed
+     * Checks whether jakarta.el is on the classpath and a {@link ExpressionFactory} can be constructed
      *
-     * @return if javax.el can be used
+     * @return if jakarta.el can be used
      */
     public static Boolean isSupported() {
         return isSupported(ELExpressionFactory.class.getClassLoader());
     }
 
     /**
-     * Checks whether javax.el is on the classpath and a {@link ExpressionFactory} can be constructed
+     * Checks whether jakarta.el is on the classpath and a {@link ExpressionFactory} can be constructed
      *
      * @param classLoader class loader to resolve {@link ExpressionFactory}
-     * @return if javax.el can be used
+     * @return if jakarta.el can be used
      */
     public static Boolean isSupported(ClassLoader classLoader) {
         if (isJavaxEL == null) {
             try {
                 isJavaxEL = newInstance(classLoader) != null;
 
-                LOG.info("javax.el support is {}", isJavaxEL);
+                LOG.info("jakarta.el support is {}", isJavaxEL);
             } catch (IllegalStateException ex) {
-                LOG.info("javax.el is not supported; {}", ex.getMessage());
+                LOG.info("jakarta.el is not supported; {}", ex.getMessage());
 
                 isJavaxEL = false;
             }
@@ -72,7 +72,7 @@ public final class ELExpressionFactory {
      *
      * @param classLoader class loader to resolve {@link ExpressionFactory}
      * @return {@link ExpressionFactory} instance
-     * @throws IllegalStateException if javax.el is not on the class path or a {@link ExpressionFactory} instance could not be constructed
+     * @throws IllegalStateException if jakarta.el is not on the class path or a {@link ExpressionFactory} instance could not be constructed
      */
     public static ExpressionFactory newInstance(ClassLoader classLoader) throws IllegalStateException {
         resolveClassForName();

--- a/core/src/main/java/com/github/dozermapper/core/el/ELExpressionFactory.java
+++ b/core/src/main/java/com/github/dozermapper/core/el/ELExpressionFactory.java
@@ -15,7 +15,7 @@
  */
 package com.github.dozermapper.core.el;
 
-import javax.el.ExpressionFactory;
+import jakarta.el.ExpressionFactory;
 
 import com.github.dozermapper.core.util.MappingUtils;
 
@@ -81,7 +81,7 @@ public final class ELExpressionFactory {
     }
 
     private static void resolveClassForName() throws IllegalStateException {
-        String expressionFactoryProperty = System.getProperty("javax.el.ExpressionFactory");
+        String expressionFactoryProperty = System.getProperty("jakarta.el.ExpressionFactory");
         String expressionFactoryClass = MappingUtils.isBlankOrNull(expressionFactoryProperty)
                 ? "com.sun.el.ExpressionFactoryImpl"
                 : expressionFactoryProperty;

--- a/core/src/main/java/com/github/dozermapper/core/el/NoopELEngine.java
+++ b/core/src/main/java/com/github/dozermapper/core/el/NoopELEngine.java
@@ -19,7 +19,7 @@ import java.lang.reflect.Method;
 
 /**
  * ELEngine implementation that has no implementation logic.
- * Use when javax.el dependency is not on the class path.
+ * Use when jakarta.el dependency is not on the class path.
  */
 public class NoopELEngine implements ELEngine {
 

--- a/core/src/main/java/com/github/dozermapper/core/el/TcclELEngine.java
+++ b/core/src/main/java/com/github/dozermapper/core/el/TcclELEngine.java
@@ -15,8 +15,8 @@
  */
 package com.github.dozermapper.core.el;
 
-import javax.el.ExpressionFactory;
-import javax.el.ValueExpression;
+import jakarta.el.ExpressionFactory;
+import jakarta.el.ValueExpression;
 
 /**
  * ELEngine extension of {@link DefaultELEngine} which uses ContextClassLoader when resolving expressions.

--- a/core/src/main/java/com/github/dozermapper/core/el/contexts/SimpleELContext.java
+++ b/core/src/main/java/com/github/dozermapper/core/el/contexts/SimpleELContext.java
@@ -15,10 +15,10 @@
  */
 package com.github.dozermapper.core.el.contexts;
 
-import javax.el.ELContext;
-import javax.el.ELResolver;
-import javax.el.FunctionMapper;
-import javax.el.VariableMapper;
+import jakarta.el.ELContext;
+import jakarta.el.ELResolver;
+import jakarta.el.FunctionMapper;
+import jakarta.el.VariableMapper;
 
 import com.github.dozermapper.core.el.mappers.FunctionsMapper;
 import com.github.dozermapper.core.el.mappers.VariablesMapper;

--- a/core/src/main/java/com/github/dozermapper/core/el/contexts/package-info.java
+++ b/core/src/main/java/com/github/dozermapper/core/el/contexts/package-info.java
@@ -14,6 +14,6 @@
  * limitations under the License.
  */
 /**
- * Default {@link javax.el.ELContext} implementations
+ * Default {@link jakarta.el.ELContext} implementations
  */
 package com.github.dozermapper.core.el.contexts;

--- a/core/src/main/java/com/github/dozermapper/core/el/mappers/FunctionsMapper.java
+++ b/core/src/main/java/com/github/dozermapper/core/el/mappers/FunctionsMapper.java
@@ -19,7 +19,7 @@ import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.Map;
 
-import javax.el.FunctionMapper;
+import jakarta.el.FunctionMapper;
 
 /**
  * Maps between EL function names and methods.

--- a/core/src/main/java/com/github/dozermapper/core/el/mappers/VariablesMapper.java
+++ b/core/src/main/java/com/github/dozermapper/core/el/mappers/VariablesMapper.java
@@ -18,8 +18,8 @@ package com.github.dozermapper.core.el.mappers;
 import java.util.HashMap;
 import java.util.Map;
 
-import javax.el.ValueExpression;
-import javax.el.VariableMapper;
+import jakarta.el.ValueExpression;
+import jakarta.el.VariableMapper;
 
 /**
  * Maps between EL variables and the EL expressions

--- a/core/src/main/java/com/github/dozermapper/core/el/mappers/package-info.java
+++ b/core/src/main/java/com/github/dozermapper/core/el/mappers/package-info.java
@@ -14,6 +14,6 @@
  * limitations under the License.
  */
 /**
- * EL Mapper extensions for {@link javax.el.FunctionMapper} and {@link javax.el.VariableMapper}
+ * EL Mapper extensions for {@link jakarta.el.FunctionMapper} and {@link jakarta.el.VariableMapper}
  */
 package com.github.dozermapper.core.el.mappers;

--- a/core/src/main/java/com/github/dozermapper/core/el/package-info.java
+++ b/core/src/main/java/com/github/dozermapper/core/el/package-info.java
@@ -14,6 +14,6 @@
  * limitations under the License.
  */
 /**
- * Extensions for {@link javax.el}
+ * Extensions for {@link jakarta.el}
  */
 package com.github.dozermapper.core.el;

--- a/core/src/main/java/com/github/dozermapper/core/factory/ConstructionStrategies.java
+++ b/core/src/main/java/com/github/dozermapper/core/factory/ConstructionStrategies.java
@@ -321,7 +321,7 @@ public final class ConstructionStrategies {
             this.jaxbBeanFactory = jaxbBeanFactory;
             this.beanContainer = beanContainer;
             try {
-                jaxbObjectType = Class.forName("javax.xml.bind.JAXBElement");
+                jaxbObjectType = Class.forName("jakarta.xml.bind.JAXBElement");
                 jaxbBeansAvailable = true;
             } catch (ClassNotFoundException e) {
                 jaxbBeansAvailable = false;

--- a/core/src/test/java/com/github/dozermapper/core/converters/JAXBElementConverterTest.java
+++ b/core/src/test/java/com/github/dozermapper/core/converters/JAXBElementConverterTest.java
@@ -20,7 +20,7 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
 
-import javax.xml.bind.JAXBElement;
+import jakarta.xml.bind.JAXBElement;
 import javax.xml.datatype.DatatypeFactory;
 import javax.xml.datatype.XMLGregorianCalendar;
 
@@ -58,7 +58,7 @@ public class JAXBElementConverterTest extends AbstractDozerTest {
         Object conversion = converter.convert(JAXBElement.class, "dummy");
 
         assertNotNull(conversion);
-        assertEquals("javax.xml.bind.JAXBElement", conversion.getClass().getCanonicalName());
+        assertEquals("jakarta.xml.bind.JAXBElement", conversion.getClass().getCanonicalName());
         assertEquals("java.lang.String", JAXBElement.class.cast(conversion).getDeclaredType().getCanonicalName());
         assertEquals("dummy", JAXBElement.class.cast(conversion).getValue());
     }
@@ -72,7 +72,7 @@ public class JAXBElementConverterTest extends AbstractDozerTest {
         Object conversion = converter.convert(JAXBElement.class, calendar);
 
         assertNotNull(conversion);
-        assertEquals("javax.xml.bind.JAXBElement", conversion.getClass().getCanonicalName());
+        assertEquals("jakarta.xml.bind.JAXBElement", conversion.getClass().getCanonicalName());
         assertEquals("javax.xml.datatype.XMLGregorianCalendar", JAXBElement.class.cast(conversion).getDeclaredType().getCanonicalName());
         assertEquals(calendar.toString(), JAXBElement.class.cast(conversion).getValue().toString());
     }
@@ -85,7 +85,7 @@ public class JAXBElementConverterTest extends AbstractDozerTest {
         Object conversion = converter.convert(JAXBElement.class, calendar);
 
         assertNotNull(conversion);
-        assertEquals("javax.xml.bind.JAXBElement", conversion.getClass().getCanonicalName());
+        assertEquals("jakarta.xml.bind.JAXBElement", conversion.getClass().getCanonicalName());
         assertEquals("javax.xml.datatype.XMLGregorianCalendar", JAXBElement.class.cast(conversion).getDeclaredType().getCanonicalName());
 
         DatatypeFactory instance = DatatypeFactory.newInstance();
@@ -102,7 +102,7 @@ public class JAXBElementConverterTest extends AbstractDozerTest {
         Object conversion = converter.convert(JAXBElement.class, calendar);
 
         assertNotNull(conversion);
-        assertEquals("javax.xml.bind.JAXBElement", conversion.getClass().getCanonicalName());
+        assertEquals("jakarta.xml.bind.JAXBElement", conversion.getClass().getCanonicalName());
         assertEquals("javax.xml.datatype.XMLGregorianCalendar", JAXBElement.class.cast(conversion).getDeclaredType().getCanonicalName());
 
         DatatypeFactory instance = DatatypeFactory.newInstance();
@@ -119,7 +119,7 @@ public class JAXBElementConverterTest extends AbstractDozerTest {
         Object conversion = converter.convert(JAXBElement.class, calendar);
 
         assertNotNull(conversion);
-        assertEquals("javax.xml.bind.JAXBElement", conversion.getClass().getCanonicalName());
+        assertEquals("jakarta.xml.bind.JAXBElement", conversion.getClass().getCanonicalName());
         assertEquals("java.lang.String", JAXBElement.class.cast(conversion).getDeclaredType().getCanonicalName());
         assertEquals("01.02.2001", JAXBElement.class.cast(conversion).getValue());
     }
@@ -132,7 +132,7 @@ public class JAXBElementConverterTest extends AbstractDozerTest {
         Object conversion = converter.convert(JAXBElement.class, calendar);
 
         assertNotNull(conversion);
-        assertEquals("javax.xml.bind.JAXBElement", conversion.getClass().getCanonicalName());
+        assertEquals("jakarta.xml.bind.JAXBElement", conversion.getClass().getCanonicalName());
         assertEquals("java.lang.String", JAXBElement.class.cast(conversion).getDeclaredType().getCanonicalName());
         assertEquals("01.02.2001", JAXBElement.class.cast(conversion).getValue());
     }

--- a/docs/asciidoc/documentation/expressionlanguage.adoc
+++ b/docs/asciidoc/documentation/expressionlanguage.adoc
@@ -1,12 +1,12 @@
 == Expression Language
 === Usage
-Dozer provides optional support for standard java expression language (javax.el).
+Dozer provides optional support for standard java expression language (jakarta.el).
 
 Current support for expressions is start-up time only.
 Expressions are *not* resolved during each mapping, but rather during mapping loading time.
 Each attribute or node value can contain a valid EL expression ${}.
 
-Dozer supports any EL implementation written against javax.el standard API.
+Dozer supports any EL implementation written against jakarta.el standard API.
 Functionality is tested with 'glassfish' internally, but other EL providers should work as well.
 
 You can define global variables for the mapper in *variables* configuration block.
@@ -32,14 +32,9 @@ To enable it, you must add the below dependencies to your classpath:
 [source,xml,prettyprint]
 ----
 <dependency>
-    <groupId>javax.el</groupId>
-    <artifactId>javax.el-api</artifactId>
-    <version>3.0.0</version>
-</dependency>
-<dependency>
-    <groupId>org.glassfish</groupId>
-    <artifactId>javax.el</artifactId>
-    <version>3.0.0</version>
+  <groupId>org.glassfish</groupId>
+  <artifactId>jakarta.el</artifactId>
+  <version>4.0.0</version>
 </dependency>
 ----
 

--- a/plugins-parent/pom.xml
+++ b/plugins-parent/pom.xml
@@ -438,74 +438,17 @@
 
     <profiles>
         <profile>
-            <id>jdk8-build</id>
-            <activation>
-                <jdk>1.8</jdk>
-            </activation>
-            <build>
-                <plugins>
-                    <!-- Core Java Plugins; alphabetical order -->
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-compiler-plugin</artifactId>
-                        <configuration>
-                            <source>${project.java.version}</source>
-                            <target>${project.java.version}</target>
-                            <encoding>${project.build.sourceEncoding}</encoding>
-                            <compilerArgs>
-                                <compilerArg>-Xdiags:verbose</compilerArg>
-                                <compilerArg>-Xlint:all</compilerArg>
-                                <compilerArg>-Xlint:-processing</compilerArg>
-                                <!--<compilerArg>-Werror</compilerArg>-->
-                            </compilerArgs>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <profile>
-            <id>between-jdk9-and-jdk10-build</id>
-            <activation>
-                <jdk>[9,11)</jdk>
-            </activation>
-            <build>
-                <plugins>
-                    <!-- Core Java Plugins; alphabetical order -->
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-compiler-plugin</artifactId>
-                        <configuration>
-                            <source>${project.java.version}</source>
-                            <target>${project.java.version}</target>
-                            <encoding>${project.build.sourceEncoding}</encoding>
-                            <compilerArgs>
-                                <compilerArg>-Xdiags:verbose</compilerArg>
-                                <compilerArg>-Xlint:all</compilerArg>
-                                <compilerArg>-Xlint:-processing</compilerArg>
-                                <!--<compilerArg>-Werror</compilerArg>-->
-                            </compilerArgs>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <argLine>--add-modules java.xml.bind,java.activation
-                                --add-opens java.base/java.lang=ALL-UNNAMED
-                                --add-exports=java.xml.bind/com.sun.xml.internal.bind=ALL-UNNAMED
-                                --add-exports=java.xml.bind/com.sun.xml.internal.bind.v2=ALL-UNNAMED
-                                --add-exports=java.xml.bind/com.sun.xml.internal.bind.v2.runtime.reflect=ALL-UNNAMED
-                            </argLine>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <profile>
             <id>jdk11-and-above-build</id>
             <activation>
                 <jdk>[11,)</jdk>
             </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>org.glassfish.jaxb</groupId>
+                    <artifactId>jaxb-runtime</artifactId>
+                </dependency>
+            </dependencies>
+
             <build>
                 <plugins>
                     <!-- Core Java Plugins; alphabetical order -->

--- a/plugins-parent/pom.xml
+++ b/plugins-parent/pom.xml
@@ -53,7 +53,7 @@
         <!-- Codehaus Plugins versions; alphabetical order -->
         <build-helper-maven-plugin.version>3.0.0</build-helper-maven-plugin.version>
         <exec-maven-plugin.version>1.6.0</exec-maven-plugin.version>
-        <jaxb2-maven-plugin.version>1.6</jaxb2-maven-plugin.version>
+        <jaxb2-maven-plugin.version>3.1.0</jaxb2-maven-plugin.version>
 
         <!-- GitHub Plugins versions; alphabetical order -->
         <spotbugs-maven-plugin.version>3.1.8</spotbugs-maven-plugin.version>
@@ -256,23 +256,23 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <configuration>
-                    <excludePackageNames>com.github.dozermapper.core.vo.jaxb.employee:com.github.dozermapper.protobuf.vo.proto</excludePackageNames>
-                    <failOnError>true</failOnError>
-                    <additionalparam>-Xdoclint:all</additionalparam>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>attach-javadocs</id>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
+<!--            <plugin>-->
+<!--                <groupId>org.apache.maven.plugins</groupId>-->
+<!--                <artifactId>maven-javadoc-plugin</artifactId>-->
+<!--                <configuration>-->
+<!--                    <excludePackageNames>com.github.dozermapper.core.vo.jaxb.employee:com.github.dozermapper.protobuf.vo.proto</excludePackageNames>-->
+<!--                    <failOnError>true</failOnError>-->
+<!--                    <additionalparam>-Xdoclint:all</additionalparam>-->
+<!--                </configuration>-->
+<!--                <executions>-->
+<!--                    <execution>-->
+<!--                        <id>attach-javadocs</id>-->
+<!--                        <goals>-->
+<!--                            <goal>jar</goal>-->
+<!--                        </goals>-->
+<!--                    </execution>-->
+<!--                </executions>-->
+<!--            </plugin>-->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>

--- a/plugins-parent/pom.xml
+++ b/plugins-parent/pom.xml
@@ -260,7 +260,9 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <configuration>
-                    <excludePackageNames>com.github.dozermapper.core.vo.jaxb.employee:com.github.dozermapper.protobuf.vo.proto</excludePackageNames>
+                    <excludePackageNames>
+                        com.github.dozermapper.core.vo.jaxb.employee:com.github.dozermapper.protobuf.vo.proto
+                    </excludePackageNames>
                     <failOnError>true</failOnError>
                     <additionalparam>-Xdoclint:all</additionalparam>
                 </configuration>
@@ -281,7 +283,9 @@
                         <manifestEntries>
                             <Bundle-SymbolicName>${project.groupId}.${project.artifactId}.source</Bundle-SymbolicName>
                             <Bundle-Version>${osgi.version.clean}</Bundle-Version>
-                            <Eclipse-SourceBundle>${project.groupId}.${project.artifactId};version="${osgi.version.clean}"</Eclipse-SourceBundle>
+                            <Eclipse-SourceBundle>
+                                ${project.groupId}.${project.artifactId};version="${osgi.version.clean}"
+                            </Eclipse-SourceBundle>
                         </manifestEntries>
                     </archive>
                 </configuration>

--- a/plugins-parent/pom.xml
+++ b/plugins-parent/pom.xml
@@ -256,23 +256,23 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
             </plugin>
-<!--            <plugin>-->
-<!--                <groupId>org.apache.maven.plugins</groupId>-->
-<!--                <artifactId>maven-javadoc-plugin</artifactId>-->
-<!--                <configuration>-->
-<!--                    <excludePackageNames>com.github.dozermapper.core.vo.jaxb.employee:com.github.dozermapper.protobuf.vo.proto</excludePackageNames>-->
-<!--                    <failOnError>true</failOnError>-->
-<!--                    <additionalparam>-Xdoclint:all</additionalparam>-->
-<!--                </configuration>-->
-<!--                <executions>-->
-<!--                    <execution>-->
-<!--                        <id>attach-javadocs</id>-->
-<!--                        <goals>-->
-<!--                            <goal>jar</goal>-->
-<!--                        </goals>-->
-<!--                    </execution>-->
-<!--                </executions>-->
-<!--            </plugin>-->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <excludePackageNames>com.github.dozermapper.core.vo.jaxb.employee:com.github.dozermapper.protobuf.vo.proto</excludePackageNames>
+                    <failOnError>true</failOnError>
+                    <additionalparam>-Xdoclint:all</additionalparam>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -262,6 +262,10 @@
                                 </goals>
                             </execution>
                         </executions>
+                      <configuration>
+                        <source>8</source>
+                        <detectJavaApiLink>false</detectJavaApiLink>
+                    </configuration>
                     </plugin>
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -262,10 +262,6 @@
                                 </goals>
                             </execution>
                         </executions>
-                      <configuration>
-                        <source>8</source>
-                        <detectJavaApiLink>false</detectJavaApiLink>
-                    </configuration>
                     </plugin>
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>

--- a/tests/dozer-osgi-tests/pom.xml
+++ b/tests/dozer-osgi-tests/pom.xml
@@ -105,13 +105,8 @@
 
         <!-- Provided dependencies; javax.el -->
         <dependency>
-            <groupId>javax.el</groupId>
-            <artifactId>javax.el-api</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish</groupId>
-            <artifactId>javax.el</artifactId>
+          <groupId>org.glassfish</groupId>
+          <artifactId>jakarta.el</artifactId>
             <scope>test</scope>
         </dependency>
 
@@ -184,8 +179,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>javax.inject</groupId>
-            <artifactId>javax.inject</artifactId>
+          <groupId>jakarta.inject</groupId>
+          <artifactId>jakarta.inject-api</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/tests/dozer-osgi-tests/pom.xml
+++ b/tests/dozer-osgi-tests/pom.xml
@@ -105,8 +105,8 @@
 
         <!-- Provided dependencies; jakarta.el -->
         <dependency>
-          <groupId>org.glassfish</groupId>
-          <artifactId>jakarta.el</artifactId>
+            <groupId>org.glassfish</groupId>
+            <artifactId>jakarta.el</artifactId>
             <scope>test</scope>
         </dependency>
 
@@ -179,8 +179,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-          <groupId>jakarta.inject</groupId>
-          <artifactId>jakarta.inject-api</artifactId>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/tests/dozer-osgi-tests/pom.xml
+++ b/tests/dozer-osgi-tests/pom.xml
@@ -103,7 +103,7 @@
             <scope>test</scope>
         </dependency>
 
-        <!-- Provided dependencies; javax.el -->
+        <!-- Provided dependencies; jakarta.el -->
         <dependency>
           <groupId>org.glassfish</groupId>
           <artifactId>jakarta.el</artifactId>

--- a/tests/dozer-osgi-tests/src/test/java/com/github/dozermapper/osgitests/support/BundleOptions.java
+++ b/tests/dozer-osgi-tests/src/test/java/com/github/dozermapper/osgitests/support/BundleOptions.java
@@ -67,8 +67,7 @@ public final class BundleOptions {
                 localBundle("javassist.link"),
 
                 // Optional; EL
-                localBundle("jakarta.el-api.link"),
-                localBundle("com.sun.el.javax.el.link"),
+                localBundle("org.glassfish.jakarta.el.link"),
 
                 // Optional; Hibernate
                 features(maven().groupId("org.apache.karaf.features")

--- a/tests/dozer-osgi-tests/src/test/java/com/github/dozermapper/osgitests/support/BundleOptions.java
+++ b/tests/dozer-osgi-tests/src/test/java/com/github/dozermapper/osgitests/support/BundleOptions.java
@@ -67,7 +67,7 @@ public final class BundleOptions {
                 localBundle("javassist.link"),
 
                 // Optional; EL
-                localBundle("javax.el-api.link"),
+                localBundle("jakarta.el-api.link"),
                 localBundle("com.sun.el.javax.el.link"),
 
                 // Optional; Hibernate

--- a/tests/dozer-osgi-tests/src/test/java/com/github/dozermapper/osgitests/support/PaxExamTestSupport.java
+++ b/tests/dozer-osgi-tests/src/test/java/com/github/dozermapper/osgitests/support/PaxExamTestSupport.java
@@ -21,7 +21,7 @@ import java.io.FileNotFoundException;
 import java.io.InputStream;
 import java.net.URL;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 import org.junit.After;
 import org.junit.Before;

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -37,8 +37,8 @@
         <!--
         <module>dozer-osgi-tests-model</module>
         <module>dozer-osgi-tests</module>
-        -->
         <module>dozer-wildfly-tests</module>
+        -->
         <module>dozer-jmh-tests</module>
     </modules>
 

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -38,7 +38,7 @@
         <module>dozer-osgi-tests-model</module>
         <module>dozer-osgi-tests</module>
         -->
-        <module>dozer-wildfly-tests</module>
+<!--        <module>dozer-wildfly-tests</module>-->
         <module>dozer-jmh-tests</module>
     </modules>
 

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -38,7 +38,7 @@
         <module>dozer-osgi-tests-model</module>
         <module>dozer-osgi-tests</module>
         -->
-<!--        <module>dozer-wildfly-tests</module>-->
+        <module>dozer-wildfly-tests</module>
         <module>dozer-jmh-tests</module>
     </modules>
 


### PR DESCRIPTION
## Issue link
No issue
## Purpose
Support Jakarta to use Dozer in the latest version of Spring Boot and Java EE
## Approach
Migrated dependencies and packages

## Notes
* Minumum supported version of JDK is 11 because of new Jakarta dependencies
* Was not added support of Spring 6
* Excluded `dozer-wildfly-tests` module because it is not straightforward to migrate to a new version of wildly with support of Java EE 9 and JDK 11

## Open Questions and Pre-Merge TODOs
- [ ] Issue created
- [ ] Unit tests pass
- [ ] Documentation updated
- [ ] Travis build passed
