### PR TITLE
Fix issue Set cannot be cast to List(#830)

### DIFF
--- a/core/src/main/java/com/github/dozermapper/core/MappingProcessor.java
+++ b/core/src/main/java/com/github/dozermapper/core/MappingProcessor.java
@@ -630,10 +630,13 @@ public class MappingProcessor implements Mapper {
             result = addToSet(srcObj, fieldMap, Arrays.asList((Object[])srcCollectionValue), destObj);
         } else if (CollectionUtils.isCollection(srcFieldType) && CollectionUtils.isSet(destCollectionType)) {
             // Collection to Set
-            result = addToSet(srcObj, fieldMap, (Collection<?>)srcCollectionValue, destObj);
-        } else if (CollectionUtils.isCollection(srcFieldType) && MappingUtils.isSupportedMap(destCollectionType)) {
+            result = addToSet(srcObj, fieldMap, (Collection<?>) srcCollectionValue, destObj);
+        } else if (CollectionUtils.isList(srcFieldType) && MappingUtils.isSupportedMap(destCollectionType)) {
             // List to Map value
-            result = mapListToList(srcObj, (List<?>)srcCollectionValue, fieldMap, destObj);
+            result = mapListToList(srcObj, (List<?>) srcCollectionValue, fieldMap, destObj);
+        } else if (CollectionUtils.isSet(srcFieldType) && MappingUtils.isSupportedMap(destCollectionType)) {
+            // Set to Map value
+            result = mapListToList(srcObj, (Set<?>) srcCollectionValue, fieldMap, destObj);
         } else if (CollectionUtils.isCollection(srcFieldType) && CollectionUtils.isList(destCollectionType)) {
             // List to List
             // Set to List

--- a/core/src/test/java/com/github/dozermapper/core/MappingProcessorTest.java
+++ b/core/src/test/java/com/github/dozermapper/core/MappingProcessorTest.java
@@ -16,7 +16,11 @@
 package com.github.dozermapper.core;
 
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import com.github.dozermapper.core.vo.A;
 import com.github.dozermapper.core.vo.B;
@@ -156,5 +160,40 @@ public class MappingProcessorTest extends AbstractDozerTest {
             return id;
         }
     }
+    public static class Source {
+        Map<String, Set<String>> map;
 
+        public Map<String, Set<String>> getMap() {
+            return map;
+        }
+
+        public void setMap(Map<String, Set<String>> map) {
+            this.map = map;
+        }
+    }
+
+    public static class Target {
+        Map<String, Set<String>> map;
+
+        public Map<String, Set<String>> getMap() {
+            return map;
+        }
+
+        public void setMap(Map<String, Set<String>> map) {
+            this.map = map;
+        }
+    }
+
+    @Test
+    public void testSourceToTargetMapping() {
+        final Mapper mapper = DozerBeanMapperBuilder.create().build();
+        Source source = new Source();
+        Map<String, Set<String>> sourceMap = new HashMap<>();
+        sourceMap.put("foo", new HashSet<>(List.of("bar")));
+        source.setMap(sourceMap);
+        Target target = mapper.map(source, Target.class);
+        assertNotNull(target.getMap());
+        assertEquals(source.getMap().size(), target.getMap().size());
+
+    }
 }


### PR DESCRIPTION
## Issue link
_All PRs **MUST** have a corresponding issue linked and issue number in PR name. i.e.:_

[ISSUE: 830] Fix issue Set cannot be cast to List
link issue: https://github.com/DozerMapper/dozer/issues/830


## Approach
the issue from this code
`else if (CollectionUtils.isCollection(srcFieldType) && MappingUtils.isSupportedMap(destCollectionType)) {
            // List to Map value
            result = mapListToList(srcObj, (List<?>)srcCollectionValue, fieldMap, destObj);
        }`
Both List and Set are Collection, when try to cast Set to List, it will throws exception

